### PR TITLE
Harden the gangway e2e trigger against rate limiting

### DIFF
--- a/.tekton/integration-tests/pipelines/compliance-operator-fbc-e2e-test-trigger.yaml
+++ b/.tekton/integration-tests/pipelines/compliance-operator-fbc-e2e-test-trigger.yaml
@@ -111,76 +111,88 @@ spec:
                     }
                   }
                 }')
-              
+
               echo "JSON payload:"
               echo "${JSON_PAYLOAD}"
 
               # Read the token from the secret file
               GANGWAY_API_TOKEN=$(cat /secrets/gangway-api-token/gangway_api_token)
 
-              # Add retry mechanism
+              # Retry the trigger POST only. Once a job is triggered we must never POST
+              # again: every re-POST launches a duplicate prow job that competes for the
+              # same machine pool.
               MAX_RETRIES=3
               RETRY=0
-              
+              JOB_ID=""
+
               while [ ${RETRY} -lt ${MAX_RETRIES} ]; do
                 if [ ${RETRY} -gt 0 ]; then
-                  echo "Retry attempt ${RETRY}/${MAX_RETRIES} - waiting 30 seconds before retry..."
-                  sleep 30
+                  BACKOFF=$(( 30 * RETRY + (RANDOM % 30) ))
+                  echo "Retry attempt ${RETRY}/${MAX_RETRIES} - waiting ${BACKOFF} seconds before retry..."
+                  sleep ${BACKOFF}
                 fi
-                
-                echo "Trigger the OpenShift CI job"          
-                RESPONSE=$(curl -X POST -d "${JSON_PAYLOAD}" -H "Content-Type: application/json" -H "Authorization: Bearer ${GANGWAY_API_TOKEN}" "${GANGWAY_API_URL}/v1/executions/${OCP_CI_JOB_NAME}")
+
+                echo "Trigger the OpenShift CI job"
+                # A rate-limited response (HTTP 429) is an HTML page, not JSON. Guard the
+                # curl and jq calls: under Tekton's default `set -e` an unguarded failure
+                # aborts the whole step before any retry logic can run.
+                RESPONSE=$(curl -s --max-time 60 -X POST -d "${JSON_PAYLOAD}" -H "Content-Type: application/json" -H "Authorization: Bearer ${GANGWAY_API_TOKEN}" "${GANGWAY_API_URL}/v1/executions/${OCP_CI_JOB_NAME}" || true)
 
                 echo "Job trigger response:"
                 echo "${RESPONSE}"
 
-                # Extract job ID from the response
-                JOB_ID=$(echo "${RESPONSE}" | jq -r '.id')
+                # Non-JSON responses yield an empty JOB_ID and fall through to a retry
+                JOB_ID=$(echo "${RESPONSE}" | jq -r '.id // empty' 2>/dev/null || true)
                 echo "Job ID: ${JOB_ID}"
 
-                if [ "${JOB_ID}" != "null" ] && [ -n "${JOB_ID}" ]; then
-                  echo "Fetching job details for ID: ${JOB_ID}"
-                  
-                  # Poll job details until job_url is available
-                  MAX_ATTEMPTS=60  # Maximum number of attempts (5 minutes with 5-second intervals)
-                  ATTEMPT=0
-                  JOB_URL=""
-                  
-                  while [ ${ATTEMPT} -lt ${MAX_ATTEMPTS} ]; do
-                    echo "Attempt $((ATTEMPT + 1))/${MAX_ATTEMPTS}: Fetching job details..."
-                    
-                    JOB_DETAILS=$(curl -s -X GET -H "Authorization: Bearer ${GANGWAY_API_TOKEN}" "${GANGWAY_API_URL}/v1/executions/${JOB_ID}")
-                    echo "Job details response:"
-                    echo "${JOB_DETAILS}"
-                    
-                    # Extract job_url from the response
-                    JOB_URL=$(echo "${JOB_DETAILS}" | jq -r '.job_url')
-                    
-                    if [ "${JOB_URL}" != "null" ] && [ -n "${JOB_URL}" ] && [ "${JOB_URL}" != "" ]; then
-                      echo "Job URL found: ${JOB_URL}"
-                      break
-                    else
-                      echo "Job URL not yet available, waiting 15 seconds..."
-                      sleep 15
-                      ATTEMPT=$((ATTEMPT + 1))
-                    fi
-                  done
-                  
-                  if [ "${JOB_URL}" = "null" ] || [ -z "${JOB_URL}" ] || [ "${JOB_URL}" = "" ]; then
-                    echo "Job URL not available after ${MAX_ATTEMPTS} attempts"
-                    RETRY=$((RETRY + 1))
-                    continue
-                  else
-                    echo "Final job details with URL:"
-                    echo "${JOB_DETAILS}"
-                    exit 0
-                  fi
-                else
-                  echo "Failed to extract job ID from response"
-                  RETRY=$((RETRY + 1))
-                  continue
+                if [ -n "${JOB_ID}" ] && [ "${JOB_ID}" != "null" ]; then
+                  break
                 fi
+                echo "Failed to extract job ID from response"
+                RETRY=$((RETRY + 1))
               done
-              
-              echo "Failed to trigger job after ${MAX_RETRIES} attempts"
-              exit 1
+
+              if [ -z "${JOB_ID}" ] || [ "${JOB_ID}" = "null" ]; then
+                echo "Failed to trigger job after ${MAX_RETRIES} attempts"
+                exit 1
+              fi
+
+              echo "Fetching job details for ID: ${JOB_ID}"
+
+              # Poll job details until job_url is available. Rate-limited or malformed
+              # responses are treated as "not ready yet", never as fatal.
+              MAX_ATTEMPTS=60
+              ATTEMPT=0
+              JOB_URL=""
+
+              while [ ${ATTEMPT} -lt ${MAX_ATTEMPTS} ]; do
+                echo "Attempt $((ATTEMPT + 1))/${MAX_ATTEMPTS}: Fetching job details..."
+
+                JOB_DETAILS=$(curl -s --max-time 60 -X GET -H "Authorization: Bearer ${GANGWAY_API_TOKEN}" "${GANGWAY_API_URL}/v1/executions/${JOB_ID}" || true)
+                echo "Job details response:"
+                echo "${JOB_DETAILS}"
+
+                JOB_URL=$(echo "${JOB_DETAILS}" | jq -r '.job_url // empty' 2>/dev/null || true)
+
+                if [ -n "${JOB_URL}" ] && [ "${JOB_URL}" != "null" ]; then
+                  echo "Job URL found: ${JOB_URL}"
+                  echo "Final job details with URL:"
+                  echo "${JOB_DETAILS}"
+                  exit 0
+                fi
+
+                # Back off progressively while gangway is rate limiting us (cap at 2 min)
+                SLEEP=$(( 15 + ATTEMPT / 4 * 15 + (RANDOM % 10) ))
+                if [ ${SLEEP} -gt 120 ]; then SLEEP=120; fi
+                echo "Job URL not yet available, waiting ${SLEEP} seconds..."
+                sleep ${SLEEP}
+                ATTEMPT=$((ATTEMPT + 1))
+              done
+
+              # The job WAS triggered; only the URL lookup failed. Do not fail the task:
+              # a red result invites restarts, and each restart would trigger a duplicate
+              # prow job. The run can be located on the CI deck via the job ID above.
+              echo "WARNING: job URL not available after ${MAX_ATTEMPTS} attempts."
+              echo "The prow job was triggered successfully (job ID ${JOB_ID})."
+              echo "Look it up at ${GANGWAY_API_URL}/v1/executions/${JOB_ID} or on the CI deck."
+              exit 0


### PR DESCRIPTION
## Summary

The FBC e2e-test trigger task parses gangway responses with unguarded `jq`. When gangway rate-limits a request (HTTP 429, an nginx HTML page), jq exits non-zero and Tekton's default `set -e` kills the step immediately — before any of the script's own retry logic can run. During the v1.9.2 release testing on 2026-08-10 this failed 20 of 22 FBC e2e scenarios (commit a3a1551) with no real test failure behind them: the census scatter showed the same snapshot image passing one scenario while failing its sibling, and two live captures plus a simulation under `sh -e` confirmed the 429 -> `jq: parse error` -> instant step death mechanism on both the trigger POST and the poll paths.

A second defect amplified the impact: the retry loop re-POSTs the trigger when only the polling failed, so every retry and every manual restart of a red scenario launched a duplicate prow job competing for the same bare-metal machine pool.

## Changes

- Guard every curl/jq call so a rate-limited or malformed response is treated as "retry" instead of aborting the step (`|| true`, `jq -r '... // empty'`).
- Retry only the trigger POST, with jittered backoff; once a job ID exists, never POST again.
- Poll for the job URL with progressive backoff (15s up to a 120s cap plus jitter); if the URL never appears, exit 0 with a prominent warning and the job ID instead of failing — the prow job *was* triggered, and a red result invites manual restarts that spawn duplicate jobs.
- `--max-time 60` on all curls.

## Verification

- Patched YAML parses; the embedded script passes `bash -n`.
- Simulation: against a mock gangway returning 429 twice, the current script dies at the first response with `jq: parse error` (exit 5, zero retries — matching the live failures byte for byte); the patched script rides through and succeeds.
- All 15 fixable red scenarios from the v1.9.2 run were subsequently flipped green via serialized re-runs, confirming the candidate FBCs were never the problem.

Companion PR (same fix, older script variant): openshift/file-integrity-operator-fbc#119

🤖 Generated with [Claude Code](https://claude.com/claude-code)