### PR TITLE
CMP-4577: Add integration jobs for OCP-4-23

### DIFF
--- a/.tekton/integration-tests/integration-test-scenarios/compliance-operator-fbc-4-23-integration-tests-arm-destructive.yaml
+++ b/.tekton/integration-tests/integration-test-scenarios/compliance-operator-fbc-4-23-integration-tests-arm-destructive.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  annotations:
+    test.appstudio.openshift.io/optional: "true"
+  name: compliance-operator-fbc-4-23-e2e-tests-arm-destructive
+  namespace: ocp-isc-tenant
+spec:
+  application: compliance-operator-fbc-4-23
+  contexts:
+  - description: execute the integration test when component compliance-operator-fbc-4-23 updates
+      state
+    name: component_compliance-operator-fbc-4-23
+  params:
+    - name: gangway_api_url
+      value: https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com
+    - name: ocp_ci_job_name
+      value: periodic-ci-openshift-openshift-tests-private-release-4.23-arm64-nightly-gcp-ipi-proxy-private-f28-compliance-destructive
+    - name: index_image
+      value: MULTISTAGE_PARAM_OVERRIDE_INDEX_IMAGE
+  resolverRef:
+    params:
+      - name: url
+        value: https://github.com/openshift/compliance-operator-fbc.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/integration-tests/pipelines/compliance-operator-fbc-e2e-test-trigger.yaml
+    resolver: git
+    resourceKind: pipeline

--- a/.tekton/integration-tests/integration-test-scenarios/compliance-operator-fbc-4-23-integration-tests-arm.yaml
+++ b/.tekton/integration-tests/integration-test-scenarios/compliance-operator-fbc-4-23-integration-tests-arm.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  annotations:
+    test.appstudio.openshift.io/optional: "true"
+  name: compliance-operator-fbc-4-23-e2e-tests-arm
+  namespace: ocp-isc-tenant
+spec:
+  application: compliance-operator-fbc-4-23
+  contexts:
+  - description: execute the integration test when component compliance-operator-fbc-4-23 updates
+      state
+    name: component_compliance-operator-fbc-4-23
+  params:
+    - name: gangway_api_url
+      value: https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com
+    - name: ocp_ci_job_name
+      value: periodic-ci-openshift-openshift-tests-private-release-4.23-arm64-nightly-gcp-ipi-proxy-private-f28-compliance
+    - name: index_image
+      value: MULTISTAGE_PARAM_OVERRIDE_INDEX_IMAGE
+  resolverRef:
+    params:
+      - name: url
+        value: https://github.com/openshift/compliance-operator-fbc.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/integration-tests/pipelines/compliance-operator-fbc-e2e-test-trigger.yaml
+    resolver: git
+    resourceKind: pipeline


### PR DESCRIPTION
## Summary
- Add arm64 integration test scenarios for the OCP 4.23 FBC catalog
- Follows the existing architecture alternation pattern (4.21=arm, 4.22=amd, 4.23=arm)

## Changes
- `compliance-operator-fbc-4-23-integration-tests-arm.yaml` — non-destructive e2e test trigger
- `compliance-operator-fbc-4-23-integration-tests-arm-destructive.yaml` — destructive e2e test trigger

Both target `periodic-ci-openshift-openshift-tests-private-release-4.23-arm64-nightly-gcp-ipi-proxy-private-f28-compliance[-destructive]` via gangway.

## Context
OCP 4.23 FBC catalog and pipelines were added in #80. This adds the corresponding integration test coverage.
