### PR TITLE
CMP-4611: Add OCP 5.0 catalog and pipelines

### DIFF
--- a/.tekton/compliance-operator-fbc-5-0-pull-request.yaml
+++ b/.tekton/compliance-operator-fbc-5-0-pull-request.yaml
@@ -1,0 +1,448 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/compliance-operator-fbc?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "catalog/v5.0/***".pathChanged() || ".tekton/compliance-operator-fbc-5-0-pull-request.yaml".pathChanged() || "catalog/v5.0/Containerfile".pathChanged() )
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: compliance-operator-fbc-5-0
+    appstudio.openshift.io/component: compliance-operator-fbc-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: compliance-operator-fbc-5-0-on-pull-request
+  namespace: ocp-isc-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-fbc-5-0:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: dockerfile
+    value: catalog/v5.0/Containerfile
+  - name: path-context
+    value: catalog/v5.0
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/end-to-end/building-olm/#building-the-file-based-catalog).
+
+      _Uses `buildah` to create a container image. Its build-time tests are limited to verifying the included catalog and do not scan the image.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-fbc-builder?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "true"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "true"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default:
+      - linux/x86_64
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
+    - name: enable-cache-proxy
+      default: 'false'
+      description: Enable cache proxy configuration
+      type: string
+    - name: enable-package-registry-proxy
+      default: 'true'
+      description: Use the package registry proxy when prefetching dependencies
+      type: string
+    - name: source-date-epoch
+      type: string
+      default: ''
+      description: Sets the image created time and the SOURCE_DATE_EPOCH build argument. On its own, it does not change file timestamps inside the layers (set rewrite-timestamp to "true" for that). Leave empty to keep the actual build time.
+    - name: rewrite-timestamp
+      type: string
+      default: 'false'
+      description: When "true", clamp file modification times in the image layers to at most source-date-epoch. Does nothing unless source-date-epoch is set.
+    - name: omit-history
+      type: string
+      default: 'false'
+      description: When "true", omit the build history (history timestamps, layer metadata, etc.) from the resulting image.
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:15d3d4a7e5c70b068103a9d4c6ba2e049db8896709fc45c0bd4be49c134b0989
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:799e6093832d194293168240a6e2209479cfaad33de51d57bfcbcfead97ed038
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: run-opm-command
+      params:
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.fbc-inject-lifecycle.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).opm
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: OPM_ARGS
+        value: []
+      - name: OPM_OUTPUT_PATH
+        value: ""
+      - name: IDMS_PATH
+        value: ""
+      runAfter:
+      - fbc-inject-lifecycle
+      taskRef:
+        params:
+        - name: name
+          value: run-opm-command-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-opm-command-oci-ta:0.1@sha256:a4865bdefb5c74eec6ee5a4919ed6ab9da723326455f34a33f03e590c8f5ae77
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.run-opm-command.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: $(params.enable-package-registry-proxy)
+      runAfter:
+      - run-opm-command
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:75109b17ba38c211fafe6aa676868e16c00e451db7b61bc939b0e7cd6035900b
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_DATE_EPOCH
+        value: $(params.source-date-epoch)
+      - name: REWRITE_TIMESTAMP
+        value: $(params.rewrite-timestamp)
+      - name: OMIT_HISTORY
+        value: $(params.omit-history)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: buildah-remote-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.11.0@sha256:78529bcd4a665aad693af8b98b2fed223a0b853c4f0cf3a8620eebdd66f517ea
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-images.results.IMAGE_REF[*])
+      runAfter:
+      - build-images
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:b00c9e68e96d41c95c725805e378ccdda44e0a1e55b69eae3f9d1f0ba1a6a493
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:0ccc688a77e9b7b0b8973c132a1e840844137e77f887be4a0bec8893b0776872
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:da0cff2a36f07087798cd5f577b15f3d9e6dd4d3d08956227b298362e08ecc37
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: validate-fbc
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: validate-fbc
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.3@sha256:5ac2ab06fa8b7b7dfaa7a57cf68d3dd8de3fa9c7d6ebaef17626509c45f234a3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: fbc-target-index-pruning-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: TARGET_INDEX
+        value: registry.redhat.io/redhat/redhat-operator-index
+      - name: RENDERED_CATALOG_DIGEST
+        value: $(tasks.validate-fbc.results.RENDERED_CATALOG_DIGEST)
+      runAfter:
+      - validate-fbc
+      taskRef:
+        params:
+        - name: name
+          value: fbc-target-index-pruning-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:a7696d92734be62700723b6d2c40dfaee4809e6a1d42b28deefc7c7463176c32
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: fbc-fips-check-oci-ta
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: fbc-fips-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:11f4adee71143d1bb8504bb96edfa868be9624e0f1758fc299d7a9a86f30e8e0
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: fbc-inject-lifecycle
+      taskRef:
+        resolver: bundles
+        params:
+        - name: kind
+          value: task
+        - name: name
+          value: fbc-inject-lifecycle-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-inject-lifecycle-oci-ta:0.1@sha256:da1217be1dcec3d5b5140ea351466607005481397b31f2b81108c4fd3012fbde
+      params:
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).lifecycle
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      runAfter:
+      - clone-repository
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-compliance-operator-fbc-5-0
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/compliance-operator-fbc-5-0-push.yaml
+++ b/.tekton/compliance-operator-fbc-5-0-push.yaml
@@ -1,0 +1,445 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/compliance-operator-fbc?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "catalog/v5.0/***".pathChanged() || ".tekton/compliance-operator-fbc-5-0-push.yaml".pathChanged() || "catalog/v5.0/Containerfile".pathChanged() )
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: compliance-operator-fbc-5-0
+    appstudio.openshift.io/component: compliance-operator-fbc-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: compliance-operator-fbc-5-0-on-push
+  namespace: ocp-isc-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-fbc-5-0:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: dockerfile
+    value: catalog/v5.0/Containerfile
+  - name: path-context
+    value: catalog/v5.0
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/end-to-end/building-olm/#building-the-file-based-catalog).
+
+      _Uses `buildah` to create a container image. Its build-time tests are limited to verifying the included catalog and do not scan the image.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-fbc-builder?tab=tags)_
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "true"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "true"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default:
+      - linux/x86_64
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
+    - name: enable-cache-proxy
+      default: 'false'
+      description: Enable cache proxy configuration
+      type: string
+    - name: enable-package-registry-proxy
+      default: 'true'
+      description: Use the package registry proxy when prefetching dependencies
+      type: string
+    - name: source-date-epoch
+      type: string
+      default: ''
+      description: Sets the image created time and the SOURCE_DATE_EPOCH build argument. On its own, it does not change file timestamps inside the layers (set rewrite-timestamp to "true" for that). Leave empty to keep the actual build time.
+    - name: rewrite-timestamp
+      type: string
+      default: 'false'
+      description: When "true", clamp file modification times in the image layers to at most source-date-epoch. Does nothing unless source-date-epoch is set.
+    - name: omit-history
+      type: string
+      default: 'false'
+      description: When "true", omit the build history (history timestamps, layer metadata, etc.) from the resulting image.
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.3@sha256:15d3d4a7e5c70b068103a9d4c6ba2e049db8896709fc45c0bd4be49c134b0989
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2.5@sha256:799e6093832d194293168240a6e2209479cfaad33de51d57bfcbcfead97ed038
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: run-opm-command
+      params:
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.fbc-inject-lifecycle.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).opm
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: OPM_ARGS
+        value: []
+      - name: OPM_OUTPUT_PATH
+        value: ""
+      - name: IDMS_PATH
+        value: ""
+      runAfter:
+      - fbc-inject-lifecycle
+      taskRef:
+        params:
+        - name: name
+          value: run-opm-command-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-opm-command-oci-ta:0.1@sha256:a4865bdefb5c74eec6ee5a4919ed6ab9da723326455f34a33f03e590c8f5ae77
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.run-opm-command.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: $(params.enable-package-registry-proxy)
+      runAfter:
+      - run-opm-command
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:75109b17ba38c211fafe6aa676868e16c00e451db7b61bc939b0e7cd6035900b
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_DATE_EPOCH
+        value: $(params.source-date-epoch)
+      - name: REWRITE_TIMESTAMP
+        value: $(params.rewrite-timestamp)
+      - name: OMIT_HISTORY
+        value: $(params.omit-history)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: buildah-remote-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.11.0@sha256:78529bcd4a665aad693af8b98b2fed223a0b853c4f0cf3a8620eebdd66f517ea
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-images.results.IMAGE_REF[*])
+      runAfter:
+      - build-images
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:b00c9e68e96d41c95c725805e378ccdda44e0a1e55b69eae3f9d1f0ba1a6a493
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:0ccc688a77e9b7b0b8973c132a1e840844137e77f887be4a0bec8893b0776872
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:da0cff2a36f07087798cd5f577b15f3d9e6dd4d3d08956227b298362e08ecc37
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: validate-fbc
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: validate-fbc
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.3@sha256:5ac2ab06fa8b7b7dfaa7a57cf68d3dd8de3fa9c7d6ebaef17626509c45f234a3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: fbc-target-index-pruning-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: TARGET_INDEX
+        value: registry.redhat.io/redhat/redhat-operator-index
+      - name: RENDERED_CATALOG_DIGEST
+        value: $(tasks.validate-fbc.results.RENDERED_CATALOG_DIGEST)
+      runAfter:
+      - validate-fbc
+      taskRef:
+        params:
+        - name: name
+          value: fbc-target-index-pruning-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:a7696d92734be62700723b6d2c40dfaee4809e6a1d42b28deefc7c7463176c32
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: fbc-fips-check-oci-ta
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: fbc-fips-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:11f4adee71143d1bb8504bb96edfa868be9624e0f1758fc299d7a9a86f30e8e0
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: fbc-inject-lifecycle
+      taskRef:
+        resolver: bundles
+        params:
+        - name: kind
+          value: task
+        - name: name
+          value: fbc-inject-lifecycle-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-inject-lifecycle-oci-ta:0.1@sha256:da1217be1dcec3d5b5140ea351466607005481397b31f2b81108c4fd3012fbde
+      params:
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).lifecycle
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      runAfter:
+      - clone-repository
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-compliance-operator-fbc-5-0
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/Containerfile-ocp5.in
+++ b/Containerfile-ocp5.in
@@ -1,0 +1,15 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM registry.redhat.io/openshift5/ose-operator-registry-rhel9:vOCP_VERSION
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy declarative config root into image at /configs and pre-populate serve cache
+ADD compliance-operator /configs/compliance-operator
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,18 +3,28 @@ set -x
 
 for VERSION in ${OCP_VERSIONS}
 do
-    CONTAINERFILE="Containerfile-rhel-9.in"
+    CONTAINERFILE="Containerfile-ocp5.in"
     if [[ "$VERSION" =~ ("4.12"|"4.13"|"4.14") ]]; then
             CONTAINERFILE="Containerfile-rhel-8.in"
+    elif [[ "$VERSION" =~ ^4\. ]]; then
+            CONTAINERFILE="Containerfile-rhel-9.in"
     fi
 
     opm migrate "registry.redhat.io/redhat/redhat-operator-index:v${VERSION}" "./catalog-migrate-${VERSION}"
     mkdir -p "catalog/v${VERSION}/compliance-operator"
     cp "${CONTAINERFILE}" "catalog/v${VERSION}/Containerfile"
     sed -i "s/OCP_VERSION/${VERSION}/g" "catalog/v${VERSION}/Containerfile"
-    opm alpha convert-template basic -o yaml "./catalog-migrate-${VERSION}/compliance-operator/catalog.json" > "catalog/v${VERSION}/catalog-template.yaml"
 
-    if [[ "$OCP_V" =~ ("4.12"|"4.13"|"4.14"|"4.15"|"4.16") ]]; then
+    if [ -f "./catalog-migrate-${VERSION}/compliance-operator/catalog.json" ]; then
+        opm alpha convert-template basic -o yaml "./catalog-migrate-${VERSION}/compliance-operator/catalog.json" > "catalog/v${VERSION}/catalog-template.yaml"
+    else
+        # After moving to Konflux, we need to bootstrap the catalog from the previous version
+        PREV_MINOR=$(( ${VERSION##*.} - 1 ))
+        PREV_VERSION="${VERSION%%.*}.${PREV_MINOR}"
+        cp "catalog/v${PREV_VERSION}/catalog-template.yaml" "catalog/v${VERSION}/catalog-template.yaml"
+    fi
+
+    if [[ "$VERSION" =~ ("4.12"|"4.13"|"4.14"|"4.15"|"4.16") ]]; then
         opm alpha render-template basic -o yaml "catalog/v${VERSION}/catalog-template.yaml" > "catalog/v${VERSION}/compliance-operator/catalog.yaml"
     else
         opm alpha render-template basic -o yaml --migrate-level=bundle-object-to-csv-metadata "catalog/v${VERSION}/catalog-template.yaml" > "catalog/v${VERSION}/compliance-operator/catalog.yaml"

--- a/catalog/v5.0/Containerfile
+++ b/catalog/v5.0/Containerfile
@@ -1,0 +1,15 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM registry.redhat.io/openshift5/ose-operator-registry-rhel9:v5.0
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy declarative config root into image at /configs and pre-populate serve cache
+ADD compliance-operator /configs/compliance-operator
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/catalog/v5.0/catalog-template.yaml
+++ b/catalog/v5.0/catalog-template.yaml
@@ -1,0 +1,104 @@
+---
+entries:
+- defaultChannel: stable
+  icon:
+    base64data: iVBORw0KGgoAAAANSUhEUgAAAXwAAAF8CAYAAADM5wDKAAAACXBIWXMAAG66AABuugHW3rEXAAAeDklEQVR4nO3dz27c1t3G8YeOayC1Ac4dcIJ4lY2YKxB9BaKA7Idap0DHQBfZaQwU7aowewXmXIFooPtSKLosQq2yaRHOHYyAOgEcv+G7mBlVljX2kDz8//0AghBXhzxy7UfHv/PPyvNcAIDhe9B2BwAAzSDwAWAkCHwAGAkCHwBGgsAHgJEg8AFgJAh8ABgJAh8ARoLAB4CReNh2B4bKsqyppKkkV9Lk1mdJOm6lU0C3XG4/ryWltz5neZ5nbXVqyCyOVqjOsixPm0DffRy12iFgGK60+QGQSkrzPE/a7U7/EfgFWZY1keTd+iDcgeZcSUp2H3mer1vtTc8Q+AewLMuV5G8/CHigO64kxZLiPM/TtjvTdQT+HtuQD7QJeafd3gA4wEqb8I8I//sR+LdsJ1qD7QchD/TXSlKkTfhn7XalOwh8SZZlBdqEPKtngOG51Cb4o7Y70rbRBv528nUuRvPAWOxG/eFYJ3tHF/jbss0u6O02+wKgFdf6X/Bn7XalWaMJ/G3QLyTNWu0IgC5ZSlqMJfgHH/i3SjfnbfcFQGe90AhKPYMOfMuy5tqM6indAPiUa21G+2HbHanLIAN/e9RBpI5Oxtq2Ldd17/3fPM9rtjNAjZIkuffX0zTV9fV1s5053EpSMMSjHAYV+NvyTSTppOWu6OjoSNPpVK7rynVdTSaTm88ANtbrtdI0vfmcpqmyLNPV1VXbXZOk19oE/2DKPIMJ/DbLN47jyPO8m3BnlA5UlyTJzQ+BJEm0Wq3a6Magyjy9D/ztqD5Ww5umTk5O5HmefN/XdDpt8tXAKGVZpjiOlSSJXr9+3fTrLyX5fR/t9zrwLcvytSnh1D6qt21bvu/ffABoVxzHNx8NzQdca1PiiZt4WR16GfjbUf1C0u/rftfJyYl831cQBHW/CkBJURQpjuOmRv5/1abM07vRfu8Cf7uBKlaNxxTbtq35fK4gCCjXAD2SZZmiKFIYhnWP+q+0KfFkdb7EtF4Fft0lHMdxtFgsGM0DAxBFkRaLRZ2Tvb0r8fQm8LercF7W8ezj42PN53Nq88AAxXGsMAx1eXn56S8u53lfVvH0IvAty4pUwxk4juMoiiKWUQIjkCSJgiCoa8S/zPM8qOPBJj1ouwMfY1nWxLKsRIbD3rZtvXr1SlmWEfbASHiepyzL9OrVK9m28arwzLKsZLugpLM6O8Lf/sYlMjw5e35+rvl8zo5XYMTW67XCMNSLFy9MP/pKktfVFTydDPw6VuIcHx8rDMO9Z9gAGJ80TTWfz03X9zsb+p0r6WwvD09lKOxt29bLly+VJAlhD+A9rusqSRK9fPnSZJnnSFK2zbJO6dQIf/sblMjQssujoyPFccxaegCflGWZfN83eXDbtTYj/dTUA6vqzAj/Vs3eSNifn58rTVPCHsBBptOp0jTV+bmxu5JsSZ2ayO3ECN/kBK1t24rjmNU3AEpLkkS+75varduZmn7rgW8y7I+OjpQkCStwAFS2Xq/leZ6pEk8nQr8LJR0jq3Fms5nSNCXsARgxmUyUpqlmMyPbgI60ybpWtRr42x20lc+xPz8/VxRFlfsDAHdFUWSqrn+8zbzWtFbSMXU2zqtXrzjsDEDtoijS2dmZiUe1dvZOKyP87amXlcJ+dzwCYQ+gCUEQmDqW4eU2AxvX+Ah/u4s2VYXll7Zts5EKQCvSNJXneVVX8FxLcps+T7/REf6t+2cJewC9tNudW3Gkb0uKm16j33RJZ6EKK3IIewBdYCj0j7TJxMY0FvjbmlWlO2g5/AxAV7iuqzCsPPf6+ybr+Y3U8Lf/bMlUoZTDBC2ALjKweuda0rSJTVlNjfAr1e3Pz88JewCdFARB1XX6thralFX7CL/qevvZbMamKgCdFwSBlstllUfUvj6/1sCvWso5OjpSmnbmZFEA+CjXdaucvVN7aafukk6kkmG/W5EDAH1RceWOrU1m1qa2wLcsy5N0UrZ9HMcchAagVyaTieK4Ujn+ZJudtahzhB+VbXh+fs559gB6yfO8qpO4kaGufKCWGn6ViVrq9gCGoGI9v5YJXOOBX2Wi1rZtriUEMAhZlsl13bJn7tQygVtHSWeukhO1i8WCsAcwCNPpVIvFomxzW5ssNcroCH97EuaPZdoeHx+zKgfA4Hiep8vLy7LNvzB5oqbpEf6ibEMDZ1IAQOdUzLaFoW5IMhj429F9qcsfz8/PORQNwCC5rltl1c5sm61GGCvpWJYVqsRpmLZtK8sy1twDGKz1eq3pdFp2AveveZ4bqecbGeFvV+YEZdqGYUjYAxi0yWRSpbQTmLooxcgI37KshaTC/2ZxHEdZllV+PwD0wXQ61Wq1KtP0RZ7ni6rvN1XDD8o04hRMAGNSIfMCE++vHPiWZQWSnKLtjo+POT4BwKh4nqfj4+MyTZ1t1lZiYoRfqhPzufE9BQDQeRWyL6j67ko1/LIbrajdAxizCrX8Shuxqo7wgzKNKmw3BoDeq5CBQZX3Vh3hZypYv7dtW+t17Xf1AkCnTSaTMuvyV3meT8u+s/QI37IsVyUma6ndA0DpLHS22VtKlZJOUKpRUKoZAAxKhSws3bBK4PtFG5ycnHD8MQBoM3F7clLqFtjC2btTKvDLlnN8v3Q/AWBwSmZi6bJOqUnbMkcpMFkLAB8qOXlb6qiFsiWdwj+WGN0DwIdKZmOpRoUDf3tq21HRdgQ+AHyoZDYelTlBs3BJx7IsX9JF0ReZviwdAIbCsqwyzU7zPI+LNChT0vGKNig5Ew0Ao1AyI72iDRoJfE7FBID9SmZk4UZlSjqFazM//vgj6+8BYI8sy/TFF18UbpfneaFaUKERvmVZXqHeaHMyJmEPAPtNp1M5TuGtTYUzuWhJp9DDJco5AHCIkllZaAPWw4IPnxb8erlu6XN+0EP/+Mc/9K9//UuS9OTJEz19+rTlHqFODOjMcV1Xy+WycLMiX1w08AunN4E/Dn/84x/14sULvXv3ru2uoEGO4ygMQ/bZGFAyKws1KjRpW2bClvX3w/fVV1/phx9+aLsbaNFsNqtyQTe2yqzHLzJxe3ANf3udYSFHR4U35KJnnj59SthDy+VScVxoDxDuUSYzi2RzkUnbgx9604DVOYP29OlT/ec//2m7G+gILjeqrmRmHtyoSOBTv8cNwh53rVYrpWnadjd6re46fpHAL3xQD4E/TIQ99uEI9GpKZubB2VzrCH8yKfwzAh1H2AP1KZmZjPBhHmEP1KtLI/zivWCEPxiEPVC/ujOzSOAfF3mwbdsFu4KuIuyB5pTIzoOzubYRPuWcYSDsgWbVmZ21lnTQb4Q9MCxFz9LBSNQV9t9++62++eYb48+FeWma6vnz5213AwYR+PhAnSP7p0+fcsIi0BJKOngPZRxguA4K/DIHp7Eks38Ie2DYDgr8PM+zog9mlU6/EPZAN7BKB7Ui7IHuqLM6QuCPHGEPjAeBP2KEPTAuBP5IEfbA+BD4I2Qq7D///HMDvQHQFAJ/ZEyF/Zdffqk//elPBnoEoCkE/oiYDPt///vfBnoEoEkE/kgQ9gAI/BEg7AFIBP7gEfYAdgj8ASPsAdxG4A8UYQ/gLgJ/gAh7APch8AeGsAewD4E/IIQ9gI8h8AeCsAfwKQT+ABD2AA5B4PccYQ/gUAR+jxH2AIog8HuKsAdQFIHfQ4Q9gDII/J4h7AGU9bDtDuBwJm+q+t3vfqcwDCs95/LysnJfADSHwO8Jk3fQ/vzzz3r+/LmRZwHoD0o6PfDVV19x4TiAygj8jvvuu+/0ww8/tN0NAANA4HfcX/7yl7a7AGAgCPwO+9vf/qZ379613Q0AA0Hgd9g///nPtrsAYEAI/A57/Phx210AMCAEfoc9efKk7S4AGBACv8Nc1227C0Y9fPhQ8/m87W4Ao0XgozF/+MMf2u4CMGoEPhrx5Zdf6s9//nPb3QBGjcBHrR4+fKjvvvuOg9qADuAsnYH59ttv9fTp07a7cYOaPdAdBP7AfPPNN/I8r+1uAOggSjoAMBIEPgCMBIEPACNB4APASBD4ADASrNJBp71Lkvf++yErkIDSCHx00i9xrJ/mc/26Wr336w8cR58vFnoUBO10DOgxSjronDdBoP+enn4Q9pL062qlN2dnekPgA4UR+OiUN0Ggt8vlJ7/u7XKpX+K4gR4Bw0HgozMODfudnzi2ASiEwEcnFA17aVPeuTupC2A/Ah+tKxP2AIoj8NEqwh5oDoGP1pgIe2syMdQbYPgIfLTCRNg/cBx9NrB7f4E6sfEKBzG549VUGefzxaLyM/ZJejYZzB0IOASBj48yvePVVNg/ms1q2W0bx7Hm87lW92z66jLHcRSGoXzfb7sr6DBKOtjL9I5Xk2H/OIoqP+euIAh0enrau7CXpNVqpdPTUwXsQMZHEPi419soOnjH6yGh3/Wwj+NYywGsFloul4rZgYw9CHzc6+cC9fFPhX7Xw14a1mXrQ/peYBaBjw+8S5J7yzgfsy/0+xD2SZL0soyzz2q16t2kM5pB4MOYu6Hfh7AHxoRVOjDqdsAT9kC3EPgwztRRCYR9eRN2IOMelHTwgYeepweO02ofmgx7z/PktPz9muQ4jlx2IOMeBD7u9dswbO3dbYzswxa/X9OG9L3ALAIf9/qN7+vRbNb4e9sq4/i+r1kL369ps9mM3bbYi8DHXo+jqNHQb7tmH0WRLi4uelnecRxHFxcXipjzwEcwaYuP2gVw3WfWtx32O77vy/d9pWmq9XrddncOxuFpOASBj0+qO/S7Eva3MemJIaKkg4PUVd7pYtgDQ0Xg42CmQ5+wB5pF4KMQU6FP2APNI/BRWNXQJ+yBdhD4KKVs6BP2QHsIfJRWNPQJe6BdBD4qOTT0CXugfQQ+KnscRXr86tW9B649cBw9ubgg7IEOYOMVjHgUBHoUBPq/NFV+a4fqQ3aAAp1B4MOoz9ihCnQWJR0AGAkCHwBGgsAHgJEg8AFgJAh8ABgJAh8ARoLAB4CRIPABYCQIfAAYCQIfAEaCwAeAkSDwAWAkCHwAGAkCHwBGgsAHgJHgPHx02rskee+/uVAFKI/ARyf9Esf6aT7Xr6vVe7/+wHH0+WKhR0HQTseAHqOkg855EwT67+npB2EvSb+uVnpzdqY3BD5QGIGPTnkTBHq7XH7y694ul/oljhvoETAcBD4649Cw3/lpPq+xN8DwEPjohKJhL23KO3cndQHsR+CjdWXCHkBxBD5aRdgDzSHw0RoTYW9NJoZ6AwwfgY9WmAj7B46jz1zXUI+A4WPjFQ5icserqTLO54tF5Wfsk/RsMthjBzIOQODjo0zveDUV9o9ms1p228ZxrPl8rtU9m766zHEchWEo3/fb7go6jJIO9jK949Vk2D+OosrPuSsIAp2envYu7CVptVrp9PRUATuQ8REEPu71NooO3vF6SOh3PezjONZyAKuFlsulYnYgYw8CH/f6uUB9/FOh3/Wwl6T5gHbtDul7gVkEPj7wLknuLeN8zL7Q70PYJ0nSyzLOPqvVqneTzmgGgQ9j7oZ+H8IeGBNW6cCo2wFP2APdQuDDOFNHJRD25U3YgYx7UNLBBx56nh44Tqt9aDLsPc+T0/L3a5LjOHLZgYx7EPi412/DsLV3tzGyD1v8fk0b0vcCswh83Os3vq9Hs1nj722rjOP7vmYtfL+mzWYzdttiLwIfez2OokZDv+2afRRFuri46GV5x3EcXVxcKGLOAx/BpC0+ahfAdZ9Z33bY7/i+L9/3laap1ut12905GIen4RAEPj6p7tDvStjfxqQnhoiSDg5SV3mni2EPDBWBj4OZDn3CHmgWgY9CTIU+YQ80j8BHYVVDn7AH2kHgo5SyoU/YA+0h8FFa0dAn7IF2Efio5NDQJ+yB9hH4qOxxFOnxq1f3Hrj2wHH05OKCsAc6gI1XMOJREOhREOj/0lT5rR2qD9kBCnQGgQ+jPmOHKtBZlHQAYCQIfAAYCQIfAEaCwAdwL8/zZNv2wV9v2zbHNHccgd9hRe9adRyHv3AwarFY1PK1aAeB33FF/hJxlylMm8/nB139OJvNNJ/PG+gRqiDwOy4IgoP/wnGXKeoQRZHOz8/vLe/Ytq3z83OuVuwJ1uH3QBRF8n1f8/lcq9Xqvf/NcRyFYUjYo1aLxULz+VxJkihNU0mbW8E8z9NkMmm5dzgUgd8Tu7tWkyR579ep2aMpk8nk5s8h+onA7xkCHkBZ1PABYCQIfAAYCQIfAEaCwAeAkSDwAWAkWKVTs3d3llEC2I8Lc+pF4NfklzjWT/O5fr2zUQrAfg8cR78NQ/2Gtf61oKRTgzdBoP+enhL2QEG/rlb67+mp3gRB210ZJALfsLdRpLfLZdvdAHrt7XKpX+K47W4MDoFv2M8cEQsY8ROnbxpH4Bv0Lkko4wCG/LpasejBMAIfAEaCwAeAkSDwAXSWxVn7RhH4Bj30PD0ocActgP0eOI4+c922uzEoBL5hv+VeWcAI/i6ZR+Ab9hvf16MD7qAFsN+j2YzdtjUg8GvwOIr0+NUryjtAQQ8cR08uLvSYS9FrwVk6NXkUBHoUBKwjBgrg8LR6Efg14w8wgK6gpAMAI0HgA8BIEPgAMBIEPgCMBIEPACPBKp2eSW4t83RdVxPOGkGDkjvLjD1WofUKgd8TURRpsVhodee8/ePjY4VhKJczR1CjOI41n88/+PPnOI7CMJTPrtheoKTTA0EQ6Ozs7IO/bJJ0eXmpr7/+WhE7E1GTIAh0enp675+/1Wql09NTBdxB2wsEfsdFUaTlAXfknp2dffDPbaCqOI4P+vO3XC4Vcwdt5xH4HbcocEcuoyyYNi9wr2yRr0U7CPwOS5Lk3n9G77NarZSmaY09wpjw5294CPwOW6/XhdtkWWa+IxilMn/+yrRBcwj8gWGEBWAfAr/DWGOPNvHnb3gIfAAYCQIfAEaCwAeAkSDwAWAkCHwAGAkCHwBGgsAHgJEg8AFgJGoLfHZ8AkBxZU69tSxresjX1Rb4nKkBAM3I8zw75Oso6QDASHDF4cBkWcZFKDCCsuzwEPgDs1wuD7qhCMD4UNIBgJFglQ4AdEid2Vkk8C+LPPj6+rpgV3AX55ED41MiOw/O5lpLOizNrMZ13ba7AKBBdWdmkcAv3BPKOgBwuJKZeXA2Fwn8wj1hhA8AhyuZmQdnMyP8jrNtu+0uAGhIr0f4BH51vu+33QXgII7jyPO8trvRayUzs5YRfla0F1lWuAnuWCwWjPLRC2EYtt2F3iuZmQc3svI8P/iplmUd/sVbRZ6P+0VRpLOzs7a7Aew1m80URVHb3eg9y7IKt8nz/OBGRZdlXhX8es51MSAIAn3//fc6Pj5uuyvAexzH0cXFBWFvQMmsLJTJRc/SSSUdFWqQptT1DHBdV0mSKMsySmXohMlkwl4Rg+qu30vlAn9WqAETt0ZNp1NNp9O2uwHAsCYCv2hJp3CPKOkAwKeVzMpCmVxo0lYqN3H7448/MioFgD2yLNMXX3xRuF2RCVup3Fk6hSdu4zgu8RoAGIeSGVk4i8sEflK4AWUdANirZEYWblSmpONLuij6ItbjA8D9yqy/l3Sa53mhfxo0MsKXKOsAwH0qZGNStEHhwM/zfC3q+ABgRNn6/TaLCyl7AUrhHhL4APChktlYqlFjgX99fc32awC4JYqistfBNhf4eZ6nklZF2zHKB4D/KZmJq20GF1blTtvCPX39+jXnwACANputXr9+XaZp6ZFzlcCPSjWirAMAVbKwdMPC6/Dfa2xZmSSnSBvbtrnrFsDoTSaTMvX7VZ7n07LvrDLCl0r8pGHyFsDYVZisjaq8t+oIfyrpx6LtHMehlg9gtKbTqVarwuteJOmLPM+zsu+tNMLfvviyaLvVasWKHQCjFMdx2bC/rBL2UvWSjlTynxhceAxgjCpkX1T13ZVKOjcPKTF5K0l///vfuf4QwGgkSaJnz56VaVppsnbHxAhfKvmTJwgCQ68HgO6rkHmRifebCvxQUvH1RasVK3YAjEIURWVr99faZGxlRko6kmRZVijp90Xb2batLMs0mUyM9AMAuma9Xms6nZZdivnXPM/nJvphaoQvlfwJdH19zQQugEELw7Bs2EuGRveSwRG+JFmWFUmalWn7/fffy3VdY30BgC5I01Rff/112ebLPM8DU30xHfhTldiIJUnHx8fcfQtgcDzP0+Vl4e1KO5U2Wt1lsqSz24j1okzby8tLSjsABiUMwyph/8Jk2EuGR/iSZFnWRFImyS7a1rZtpWmq6XRqtE8A0LQsy+S6btna/bWkaZlrDD/G6AhfurnzdlGm7fX1tXzfN9shAGiB7/tVJmoXpsNeqiHwJSnP81AlbsSSpKurKy0WC7MdAoAGLRYLXV1dlW2+2maoccZLOjcPtixP0t/LtufYBQB9VOH4hJ1neZ4nhrrzntoCX5Isy4olnZRpy4YsAH1TcYOVJL3O87y2unYtJZ1bApU4ckHa1PMZ4QPoE8/zqoT9tTaZWZtaA7/KBK60qedzwBqAPgiCoErdXqppova2ukf4uwnc0gtRl8slk7gAOm2xWGi5XFZ5xGVdE7W31VrDv3lJhbX5O69evWK0D6BzoijS2dlZlUfUsub+PrWP8KWb0k5Q5RlnZ2ccpQygUwyEvSQFTYS91NAI/+ZlJY9Q3rFtW0mScMgagNalaVp1klYyePTxIZoO/ImkRNJR2WcQ+gDaZijsryR5TY3upYYDX7o5UTNVhXo+oQ+gLYbC/lqSa/pwtE9ppIZ/2/YbDKo8Y7dGn5o+gCZFUWQi7KVN3T4z0KVCGh/h37zYsuaSXlZ9Dqt3ADTB0AStJD1vYgnmfRof4e9sv+FKC1elzeod1ukDqNNisTAV9su2wl5qcYR/0wHLSiQdV33ObDajxAPAuCAIqm6q2rnM89wz8aCyuhD4lVfu7BwdHSlJEg5cA1DZer2W53lVj0vYaXxFzn1aK+nsbH8DPG1+Qyq5urrSdDrlblwAlSRJoul0OqiwlzoQ+NJ7oV956vv6+lrPnj2jrg+glMVioWfPnplYiSNtMq0TYS91oKRzm2VZrjblndJr9G87OjpSHMfckQvgk7Isk+/7pkb10v/CPjX1wKo6McLf2f7GeDIw0pc2JR7XdRWGrU2KA+iBMAzluu6gw17q2Ah/x+RE7s7x8fHN/6kAIG12zc7nc11elj7B/T6dqdnf1cnAl+oJfUk6Pz/XfD5nJQ8wYuv1WmEY6sWLF6Yf3dmwlzoc+NJN6McysE7/Ntu2FYYhO3SBEYqiSPP53NSk7G2Xkvyuhr3U8cDfsSwrkjQz/VzHcW7OxgAwbEmSKAgCrVarOh6/zPM8qOPBJnVq0naf7W/kc9PPXa1WevbsmTzPUxzHph8PoAPiOJbneXr27FldYf+8D2Ev9WSEv2NZli8pkqFlm3c5jqPFYkGpBxiAKIq0WCzqCnlpsxInyPO8N6PFXgW+dHOefizDk7m32bat+XyuIAhYww/0SJZliqJIYRjWUaO/7Uqben1W50tM613gSzeTuQtVuC7xUCcnJ/J9n1E/0GFRFCmOY71+/bqJ1/1V0qLLk7P79DLwd+ou8dxm27Z837/5ANCuOI5vPmoeze/0roRzV68DX6pv6eannJycyPM8+b5P2QdoQJZliuNYSZI0NZK/rfNLLg/R+8Df2d6gtVADo/27HMeR53lyXVeu67LMEzAgSRKlaao0TZUkSZ2Trx9zrU35ZhDnswwm8KWb0X4k6aTlrujo6EjT6fTmh8BkMrn5DGBjvV4rTdObz2maKssyk2faVPFamxJOr0f1tw0q8Hcsy/K0CX6n3Z7sd3x8fwWKfx1gSPbdTZGmaVN19zJW2gR90nZHTBtk4O+0WeYB0DuDKt/cZ9CBL92UeeaSztvuC4DOeiEpHFL55j6DD/yd7YathWo4kwdAby21GdVnbXekCaMJ/J1t8M8lBaLUA4zRtTZzfOFYgn5ndIG/c6vUE6jDk7sAjFnpf0E/6NLNPqMN/Nssywq0Cf5GN28BaMSlpCjP86jtjrSNwL9lW+4JxKgf6LvdaD4aW9nmYwj8PSzLcrUJfl+EP9AHK22OWYm6dnl4VxD4B9iGv7/9qO1YZgCFXWkT8jEh/2kEfkHbyV7v1gc/AIDmXElKdh9jnXwti8A3YHuUg3vrgx8CQHVXktLdxxCPOmgagV+T7QTwVJsfAJNbnyVWAwHSZvWMJK21CfXd54yJ1noQ+AAwEg/a7gAAoBkEPgCMBIEPACNB4APASBD4ADASBD4AjASBDwAjQeADwEgQ+AAwEv8PlRvxANNLSQsAAAAASUVORK5CYII=
+    mediatype: image/png
+  name: compliance-operator
+  schema: olm.package
+- entries:
+  - name: compliance-operator.v0.1.32
+    skipRange: '>=0.1.17 <0.1.32'
+  name: "4.7"
+  package: compliance-operator
+  schema: olm.channel
+- entries:
+  - name: compliance-operator.v0.1.61
+    skipRange: '>=0.1.17 <0.1.61'
+  name: release-0.1
+  package: compliance-operator
+  schema: olm.channel
+- entries:
+  - name: compliance-operator.v1.4.0
+    skipRange: '>=0.1.17 <1.4.0'
+  - name: compliance-operator.v1.4.1
+    replaces: compliance-operator.v1.4.0
+    skipRange: '>=0.1.17 <1.4.1'
+  - name: compliance-operator.v1.5.0
+    replaces: compliance-operator.v1.4.1
+    skipRange: '>=0.1.17 <1.5.0'
+  - name: compliance-operator.v1.5.1
+    replaces: compliance-operator.v1.5.0
+    skipRange: '>=0.1.17 <1.5.1'
+  - name: compliance-operator.v1.6.0
+    replaces: compliance-operator.v1.5.1
+    skipRange: '>=0.1.17 <1.6.0'
+  - name: compliance-operator.v1.6.1
+    replaces: compliance-operator.v1.6.0
+    skipRange: '>=0.1.17 <1.6.1'
+  - name: compliance-operator.v1.6.2
+    replaces: compliance-operator.v1.6.1
+    skipRange: '>=0.1.17 <1.6.2'
+  - name: compliance-operator.v1.7.0
+    replaces: compliance-operator.v1.6.2
+    skipRange: '>=0.1.17 <1.7.0'
+  - name: compliance-operator.v1.7.1
+    replaces: compliance-operator.v1.7.0
+    skipRange: '>=1.0.0 <1.7.1'
+  - name: compliance-operator.v1.8.0
+    replaces: compliance-operator.v1.7.1
+    skipRange: '>=1.0.0 <1.8.0'
+  - name: compliance-operator.v1.8.1
+    replaces: compliance-operator.v1.8.0
+    skipRange: '>=1.0.0 <1.8.1'
+  - name: compliance-operator.v1.8.2
+    replaces: compliance-operator.v1.8.1
+    skipRange: '>=1.0.0 <1.8.2'
+  - name: compliance-operator.v1.9.0
+    replaces: compliance-operator.v1.8.2
+    skipRange: '>=1.0.0 <1.9.0'
+  - name: compliance-operator.v1.9.1
+    replaces: compliance-operator.v1.9.0
+    skipRange: '>=1.0.0 <1.9.1'
+  - name: compliance-operator.v1.9.2
+    replaces: compliance-operator.v1.9.1
+    skipRange: '>=1.0.0 <1.9.2'
+  name: stable
+  package: compliance-operator
+  schema: olm.channel
+- image: registry.redhat.io/openshift4/compliance-rhel8-operator-metadata@sha256:1c06868bce1f5d7145ef658bfcc284c44011aa24a17166aa124547b38f2259e4
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:8a2194d8d26dff03ec53ac0ab93c62c268e48675079a88db18bb14a977a391be
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:f176e3a1ca1c77fb285bae8d9009a91abf310363eed4fc79a778b7306a38e480
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:cf9d9e16e4660cfff746b3517d32fc73f4d9716d61c5bcae60a60a8fb42ae38e
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:a4f4aabb46ca34f6bdd63e752f6b7de37ac41fed6cf87709506857b4819d4e98
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:91546ecf49cb877652a69f2773054af56c6cf5011d61ab190e1cfee156fc66f9
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:8e2ae4ec6fb99d69494763893be9e0a22f85f7fdfcfe09d90df07909c94877be
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:3e3061777afbdf83d18258380af8ed74a347e3daa5d0b647ed13711698c58a0f
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:03b7732826883935542572da68d92cd2e73076a762399ad433a5903450b58c39
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:49353c2eefa3bb062589a3d6d24f81e063e9911ce1920556d5a801d3afa9bf6b
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:06e4abf4a94d44728b6bfa685b6ed027962b60fc2a0060a7256297857fd5f6fa
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:0bc0b7a20ce3c6303a45a699f44d2b90597b6a62846e89a5bca285b3228a9a52
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:4d0f9d6fd1a4856a870e48b99dc3714de17a65813e0caea50564cd63c79f11ab
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:ddc2f107588e25d38af6eb58c7b106124f447deae8090ce4d78eead12487d1bf
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:e2cbcab60fad0718e63a8c9bacaca97d205735e968505a56ae1a1c523d5ee2da
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:dd5ac6b523658a5d8a07c39e20b6538686d8680d16aec8ffb0c0568a586d34be
+  schema: olm.bundle
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:bfe946d2878a37624641a92ed538c77861c355fb4a44a387944d988feca7ca95
+  schema: olm.bundle
+schema: olm.template.basic
+

--- a/catalog/v5.0/compliance-operator/catalog.yaml
+++ b/catalog/v5.0/compliance-operator/catalog.yaml
@@ -1,0 +1,6072 @@
+---
+defaultChannel: stable
+icon:
+  base64data: iVBORw0KGgoAAAANSUhEUgAAAXwAAAF8CAYAAADM5wDKAAAACXBIWXMAAG66AABuugHW3rEXAAAeDklEQVR4nO3dz27c1t3G8YeOayC1Ac4dcIJ4lY2YKxB9BaKA7Idap0DHQBfZaQwU7aowewXmXIFooPtSKLosQq2yaRHOHYyAOgEcv+G7mBlVljX2kDz8//0AghBXhzxy7UfHv/PPyvNcAIDhe9B2BwAAzSDwAWAkCHwAGAkCHwBGgsAHgJEg8AFgJAh8ABgJAh8ARoLAB4CReNh2B4bKsqyppKkkV9Lk1mdJOm6lU0C3XG4/ryWltz5neZ5nbXVqyCyOVqjOsixPm0DffRy12iFgGK60+QGQSkrzPE/a7U7/EfgFWZY1keTd+iDcgeZcSUp2H3mer1vtTc8Q+AewLMuV5G8/CHigO64kxZLiPM/TtjvTdQT+HtuQD7QJeafd3gA4wEqb8I8I//sR+LdsJ1qD7QchD/TXSlKkTfhn7XalOwh8SZZlBdqEPKtngOG51Cb4o7Y70rbRBv528nUuRvPAWOxG/eFYJ3tHF/jbss0u6O02+wKgFdf6X/Bn7XalWaMJ/G3QLyTNWu0IgC5ZSlqMJfgHH/i3SjfnbfcFQGe90AhKPYMOfMuy5tqM6indAPiUa21G+2HbHanLIAN/e9RBpI5Oxtq2Ldd17/3fPM9rtjNAjZIkuffX0zTV9fV1s5053EpSMMSjHAYV+NvyTSTppOWu6OjoSNPpVK7rynVdTSaTm88ANtbrtdI0vfmcpqmyLNPV1VXbXZOk19oE/2DKPIMJ/DbLN47jyPO8m3BnlA5UlyTJzQ+BJEm0Wq3a6Magyjy9D/ztqD5Ww5umTk5O5HmefN/XdDpt8tXAKGVZpjiOlSSJXr9+3fTrLyX5fR/t9zrwLcvytSnh1D6qt21bvu/ffABoVxzHNx8NzQdca1PiiZt4WR16GfjbUf1C0u/rftfJyYl831cQBHW/CkBJURQpjuOmRv5/1abM07vRfu8Cf7uBKlaNxxTbtq35fK4gCCjXAD2SZZmiKFIYhnWP+q+0KfFkdb7EtF4Fft0lHMdxtFgsGM0DAxBFkRaLRZ2Tvb0r8fQm8LercF7W8ezj42PN53Nq88AAxXGsMAx1eXn56S8u53lfVvH0IvAty4pUwxk4juMoiiKWUQIjkCSJgiCoa8S/zPM8qOPBJj1ouwMfY1nWxLKsRIbD3rZtvXr1SlmWEfbASHiepyzL9OrVK9m28arwzLKsZLugpLM6O8Lf/sYlMjw5e35+rvl8zo5XYMTW67XCMNSLFy9MP/pKktfVFTydDPw6VuIcHx8rDMO9Z9gAGJ80TTWfz03X9zsb+p0r6WwvD09lKOxt29bLly+VJAlhD+A9rusqSRK9fPnSZJnnSFK2zbJO6dQIf/sblMjQssujoyPFccxaegCflGWZfN83eXDbtTYj/dTUA6vqzAj/Vs3eSNifn58rTVPCHsBBptOp0jTV+bmxu5JsSZ2ayO3ECN/kBK1t24rjmNU3AEpLkkS+75varduZmn7rgW8y7I+OjpQkCStwAFS2Xq/leZ6pEk8nQr8LJR0jq3Fms5nSNCXsARgxmUyUpqlmMyPbgI60ybpWtRr42x20lc+xPz8/VxRFlfsDAHdFUWSqrn+8zbzWtFbSMXU2zqtXrzjsDEDtoijS2dmZiUe1dvZOKyP87amXlcJ+dzwCYQ+gCUEQmDqW4eU2AxvX+Ah/u4s2VYXll7Zts5EKQCvSNJXneVVX8FxLcps+T7/REf6t+2cJewC9tNudW3Gkb0uKm16j33RJZ6EKK3IIewBdYCj0j7TJxMY0FvjbmlWlO2g5/AxAV7iuqzCsPPf6+ybr+Y3U8Lf/bMlUoZTDBC2ALjKweuda0rSJTVlNjfAr1e3Pz88JewCdFARB1XX6thralFX7CL/qevvZbMamKgCdFwSBlstllUfUvj6/1sCvWso5OjpSmnbmZFEA+CjXdaucvVN7aafukk6kkmG/W5EDAH1RceWOrU1m1qa2wLcsy5N0UrZ9HMcchAagVyaTieK4Ujn+ZJudtahzhB+VbXh+fs559gB6yfO8qpO4kaGufKCWGn6ViVrq9gCGoGI9v5YJXOOBX2Wi1rZtriUEMAhZlsl13bJn7tQygVtHSWeukhO1i8WCsAcwCNPpVIvFomxzW5ssNcroCH97EuaPZdoeHx+zKgfA4Hiep8vLy7LNvzB5oqbpEf6ibEMDZ1IAQOdUzLaFoW5IMhj429F9qcsfz8/PORQNwCC5rltl1c5sm61GGCvpWJYVqsRpmLZtK8sy1twDGKz1eq3pdFp2AveveZ4bqecbGeFvV+YEZdqGYUjYAxi0yWRSpbQTmLooxcgI37KshaTC/2ZxHEdZllV+PwD0wXQ61Wq1KtP0RZ7ni6rvN1XDD8o04hRMAGNSIfMCE++vHPiWZQWSnKLtjo+POT4BwKh4nqfj4+MyTZ1t1lZiYoRfqhPzufE9BQDQeRWyL6j67ko1/LIbrajdAxizCrX8Shuxqo7wgzKNKmw3BoDeq5CBQZX3Vh3hZypYv7dtW+t17Xf1AkCnTSaTMuvyV3meT8u+s/QI37IsVyUma6ndA0DpLHS22VtKlZJOUKpRUKoZAAxKhSws3bBK4PtFG5ycnHD8MQBoM3F7clLqFtjC2btTKvDLlnN8v3Q/AWBwSmZi6bJOqUnbMkcpMFkLAB8qOXlb6qiFsiWdwj+WGN0DwIdKZmOpRoUDf3tq21HRdgQ+AHyoZDYelTlBs3BJx7IsX9JF0ReZviwdAIbCsqwyzU7zPI+LNChT0vGKNig5Ew0Ao1AyI72iDRoJfE7FBID9SmZk4UZlSjqFazM//vgj6+8BYI8sy/TFF18UbpfneaFaUKERvmVZXqHeaHMyJmEPAPtNp1M5TuGtTYUzuWhJp9DDJco5AHCIkllZaAPWw4IPnxb8erlu6XN+0EP/+Mc/9K9//UuS9OTJEz19+rTlHqFODOjMcV1Xy+WycLMiX1w08AunN4E/Dn/84x/14sULvXv3ru2uoEGO4ygMQ/bZGFAyKws1KjRpW2bClvX3w/fVV1/phx9+aLsbaNFsNqtyQTe2yqzHLzJxe3ANf3udYSFHR4U35KJnnj59SthDy+VScVxoDxDuUSYzi2RzkUnbgx9604DVOYP29OlT/ec//2m7G+gILjeqrmRmHtyoSOBTv8cNwh53rVYrpWnadjd6re46fpHAL3xQD4E/TIQ99uEI9GpKZubB2VzrCH8yKfwzAh1H2AP1KZmZjPBhHmEP1KtLI/zivWCEPxiEPVC/ujOzSOAfF3mwbdsFu4KuIuyB5pTIzoOzubYRPuWcYSDsgWbVmZ21lnTQb4Q9MCxFz9LBSNQV9t9++62++eYb48+FeWma6vnz5213AwYR+PhAnSP7p0+fcsIi0BJKOngPZRxguA4K/DIHp7Eks38Ie2DYDgr8PM+zog9mlU6/EPZAN7BKB7Ui7IHuqLM6QuCPHGEPjAeBP2KEPTAuBP5IEfbA+BD4I2Qq7D///HMDvQHQFAJ/ZEyF/Zdffqk//elPBnoEoCkE/oiYDPt///vfBnoEoEkE/kgQ9gAI/BEg7AFIBP7gEfYAdgj8ASPsAdxG4A8UYQ/gLgJ/gAh7APch8AeGsAewD4E/IIQ9gI8h8AeCsAfwKQT+ABD2AA5B4PccYQ/gUAR+jxH2AIog8HuKsAdQFIHfQ4Q9gDII/J4h7AGU9bDtDuBwJm+q+t3vfqcwDCs95/LysnJfADSHwO8Jk3fQ/vzzz3r+/LmRZwHoD0o6PfDVV19x4TiAygj8jvvuu+/0ww8/tN0NAANA4HfcX/7yl7a7AGAgCPwO+9vf/qZ379613Q0AA0Hgd9g///nPtrsAYEAI/A57/Phx210AMCAEfoc9efKk7S4AGBACv8Nc1227C0Y9fPhQ8/m87W4Ao0XgozF/+MMf2u4CMGoEPhrx5Zdf6s9//nPb3QBGjcBHrR4+fKjvvvuOg9qADuAsnYH59ttv9fTp07a7cYOaPdAdBP7AfPPNN/I8r+1uAOggSjoAMBIEPgCMBIEPACNB4APASBD4ADASrNJBp71Lkvf++yErkIDSCHx00i9xrJ/mc/26Wr336w8cR58vFnoUBO10DOgxSjronDdBoP+enn4Q9pL062qlN2dnekPgA4UR+OiUN0Ggt8vlJ7/u7XKpX+K4gR4Bw0HgozMODfudnzi2ASiEwEcnFA17aVPeuTupC2A/Ah+tKxP2AIoj8NEqwh5oDoGP1pgIe2syMdQbYPgIfLTCRNg/cBx9NrB7f4E6sfEKBzG549VUGefzxaLyM/ZJejYZzB0IOASBj48yvePVVNg/ms1q2W0bx7Hm87lW92z66jLHcRSGoXzfb7sr6DBKOtjL9I5Xk2H/OIoqP+euIAh0enrau7CXpNVqpdPTUwXsQMZHEPi419soOnjH6yGh3/Wwj+NYywGsFloul4rZgYw9CHzc6+cC9fFPhX7Xw14a1mXrQ/peYBaBjw+8S5J7yzgfsy/0+xD2SZL0soyzz2q16t2kM5pB4MOYu6Hfh7AHxoRVOjDqdsAT9kC3EPgwztRRCYR9eRN2IOMelHTwgYeepweO02ofmgx7z/PktPz9muQ4jlx2IOMeBD7u9dswbO3dbYzswxa/X9OG9L3ALAIf9/qN7+vRbNb4e9sq4/i+r1kL369ps9mM3bbYi8DHXo+jqNHQb7tmH0WRLi4uelnecRxHFxcXipjzwEcwaYuP2gVw3WfWtx32O77vy/d9pWmq9XrddncOxuFpOASBj0+qO/S7Eva3MemJIaKkg4PUVd7pYtgDQ0Xg42CmQ5+wB5pF4KMQU6FP2APNI/BRWNXQJ+yBdhD4KKVs6BP2QHsIfJRWNPQJe6BdBD4qOTT0CXugfQQ+KnscRXr86tW9B649cBw9ubgg7IEOYOMVjHgUBHoUBPq/NFV+a4fqQ3aAAp1B4MOoz9ihCnQWJR0AGAkCHwBGgsAHgJEg8AFgJAh8ABgJAh8ARoLAB4CRIPABYCQIfAAYCQIfAEaCwAeAkSDwAWAkCHwAGAkCHwBGgsAHgJHgPHx02rskee+/uVAFKI/ARyf9Esf6aT7Xr6vVe7/+wHH0+WKhR0HQTseAHqOkg855EwT67+npB2EvSb+uVnpzdqY3BD5QGIGPTnkTBHq7XH7y694ul/oljhvoETAcBD4649Cw3/lpPq+xN8DwEPjohKJhL23KO3cndQHsR+CjdWXCHkBxBD5aRdgDzSHw0RoTYW9NJoZ6AwwfgY9WmAj7B46jz1zXUI+A4WPjFQ5icserqTLO54tF5Wfsk/RsMthjBzIOQODjo0zveDUV9o9ms1p228ZxrPl8rtU9m766zHEchWEo3/fb7go6jJIO9jK949Vk2D+OosrPuSsIAp2envYu7CVptVrp9PRUATuQ8REEPu71NooO3vF6SOh3PezjONZyAKuFlsulYnYgYw8CH/f6uUB9/FOh3/Wwl6T5gHbtDul7gVkEPj7wLknuLeN8zL7Q70PYJ0nSyzLOPqvVqneTzmgGgQ9j7oZ+H8IeGBNW6cCo2wFP2APdQuDDOFNHJRD25U3YgYx7UNLBBx56nh44Tqt9aDLsPc+T0/L3a5LjOHLZgYx7EPi412/DsLV3tzGyD1v8fk0b0vcCswh83Os3vq9Hs1nj722rjOP7vmYtfL+mzWYzdttiLwIfez2OokZDv+2afRRFuri46GV5x3EcXVxcKGLOAx/BpC0+ahfAdZ9Z33bY7/i+L9/3laap1ut12905GIen4RAEPj6p7tDvStjfxqQnhoiSDg5SV3mni2EPDBWBj4OZDn3CHmgWgY9CTIU+YQ80j8BHYVVDn7AH2kHgo5SyoU/YA+0h8FFa0dAn7IF2Efio5NDQJ+yB9hH4qOxxFOnxq1f3Hrj2wHH05OKCsAc6gI1XMOJREOhREOj/0lT5rR2qD9kBCnQGgQ+jPmOHKtBZlHQAYCQIfAAYCQIfAEaCwAdwL8/zZNv2wV9v2zbHNHccgd9hRe9adRyHv3AwarFY1PK1aAeB33FF/hJxlylMm8/nB139OJvNNJ/PG+gRqiDwOy4IgoP/wnGXKeoQRZHOz8/vLe/Ytq3z83OuVuwJ1uH3QBRF8n1f8/lcq9Xqvf/NcRyFYUjYo1aLxULz+VxJkihNU0mbW8E8z9NkMmm5dzgUgd8Tu7tWkyR579ep2aMpk8nk5s8h+onA7xkCHkBZ1PABYCQIfAAYCQIfAEaCwAeAkSDwAWAkWKVTs3d3llEC2I8Lc+pF4NfklzjWT/O5fr2zUQrAfg8cR78NQ/2Gtf61oKRTgzdBoP+enhL2QEG/rlb67+mp3gRB210ZJALfsLdRpLfLZdvdAHrt7XKpX+K47W4MDoFv2M8cEQsY8ROnbxpH4Bv0Lkko4wCG/LpasejBMAIfAEaCwAeAkSDwAXSWxVn7RhH4Bj30PD0ocActgP0eOI4+c922uzEoBL5hv+VeWcAI/i6ZR+Ab9hvf16MD7qAFsN+j2YzdtjUg8GvwOIr0+NUryjtAQQ8cR08uLvSYS9FrwVk6NXkUBHoUBKwjBgrg8LR6Efg14w8wgK6gpAMAI0HgA8BIEPgAMBIEPgCMBIEPACPBKp2eSW4t83RdVxPOGkGDkjvLjD1WofUKgd8TURRpsVhodee8/ePjY4VhKJczR1CjOI41n88/+PPnOI7CMJTPrtheoKTTA0EQ6Ozs7IO/bJJ0eXmpr7/+WhE7E1GTIAh0enp675+/1Wql09NTBdxB2wsEfsdFUaTlAXfknp2dffDPbaCqOI4P+vO3XC4Vcwdt5xH4HbcocEcuoyyYNi9wr2yRr0U7CPwOS5Lk3n9G77NarZSmaY09wpjw5294CPwOW6/XhdtkWWa+IxilMn/+yrRBcwj8gWGEBWAfAr/DWGOPNvHnb3gIfAAYCQIfAEaCwAeAkSDwAWAkCHwAGAkCHwBGgsAHgJEg8AFgJGoLfHZ8AkBxZU69tSxresjX1Rb4nKkBAM3I8zw75Oso6QDASHDF4cBkWcZFKDCCsuzwEPgDs1wuD7qhCMD4UNIBgJFglQ4AdEid2Vkk8C+LPPj6+rpgV3AX55ED41MiOw/O5lpLOizNrMZ13ba7AKBBdWdmkcAv3BPKOgBwuJKZeXA2Fwn8wj1hhA8AhyuZmQdnMyP8jrNtu+0uAGhIr0f4BH51vu+33QXgII7jyPO8trvRayUzs5YRfla0F1lWuAnuWCwWjPLRC2EYtt2F3iuZmQc3svI8P/iplmUd/sVbRZ6P+0VRpLOzs7a7Aew1m80URVHb3eg9y7IKt8nz/OBGRZdlXhX8es51MSAIAn3//fc6Pj5uuyvAexzH0cXFBWFvQMmsLJTJRc/SSSUdFWqQptT1DHBdV0mSKMsySmXohMlkwl4Rg+qu30vlAn9WqAETt0ZNp1NNp9O2uwHAsCYCv2hJp3CPKOkAwKeVzMpCmVxo0lYqN3H7448/MioFgD2yLNMXX3xRuF2RCVup3Fk6hSdu4zgu8RoAGIeSGVk4i8sEflK4AWUdANirZEYWblSmpONLuij6ItbjA8D9yqy/l3Sa53mhfxo0MsKXKOsAwH0qZGNStEHhwM/zfC3q+ABgRNn6/TaLCyl7AUrhHhL4APChktlYqlFjgX99fc32awC4JYqistfBNhf4eZ6nklZF2zHKB4D/KZmJq20GF1blTtvCPX39+jXnwACANputXr9+XaZp6ZFzlcCPSjWirAMAVbKwdMPC6/Dfa2xZmSSnSBvbtrnrFsDoTSaTMvX7VZ7n07LvrDLCl0r8pGHyFsDYVZisjaq8t+oIfyrpx6LtHMehlg9gtKbTqVarwuteJOmLPM+zsu+tNMLfvviyaLvVasWKHQCjFMdx2bC/rBL2UvWSjlTynxhceAxgjCpkX1T13ZVKOjcPKTF5K0l///vfuf4QwGgkSaJnz56VaVppsnbHxAhfKvmTJwgCQ68HgO6rkHmRifebCvxQUvH1RasVK3YAjEIURWVr99faZGxlRko6kmRZVijp90Xb2batLMs0mUyM9AMAuma9Xms6nZZdivnXPM/nJvphaoQvlfwJdH19zQQugEELw7Bs2EuGRveSwRG+JFmWFUmalWn7/fffy3VdY30BgC5I01Rff/112ebLPM8DU30xHfhTldiIJUnHx8fcfQtgcDzP0+Vl4e1KO5U2Wt1lsqSz24j1okzby8tLSjsABiUMwyph/8Jk2EuGR/iSZFnWRFImyS7a1rZtpWmq6XRqtE8A0LQsy+S6btna/bWkaZlrDD/G6AhfurnzdlGm7fX1tXzfN9shAGiB7/tVJmoXpsNeqiHwJSnP81AlbsSSpKurKy0WC7MdAoAGLRYLXV1dlW2+2maoccZLOjcPtixP0t/LtufYBQB9VOH4hJ1neZ4nhrrzntoCX5Isy4olnZRpy4YsAH1TcYOVJL3O87y2unYtJZ1bApU4ckHa1PMZ4QPoE8/zqoT9tTaZWZtaA7/KBK60qedzwBqAPgiCoErdXqppova2ukf4uwnc0gtRl8slk7gAOm2xWGi5XFZ5xGVdE7W31VrDv3lJhbX5O69evWK0D6BzoijS2dlZlUfUsub+PrWP8KWb0k5Q5RlnZ2ccpQygUwyEvSQFTYS91NAI/+ZlJY9Q3rFtW0mScMgagNalaVp1klYyePTxIZoO/ImkRNJR2WcQ+gDaZijsryR5TY3upYYDX7o5UTNVhXo+oQ+gLYbC/lqSa/pwtE9ppIZ/2/YbDKo8Y7dGn5o+gCZFUWQi7KVN3T4z0KVCGh/h37zYsuaSXlZ9Dqt3ADTB0AStJD1vYgnmfRof4e9sv+FKC1elzeod1ukDqNNisTAV9su2wl5qcYR/0wHLSiQdV33ObDajxAPAuCAIqm6q2rnM89wz8aCyuhD4lVfu7BwdHSlJEg5cA1DZer2W53lVj0vYaXxFzn1aK+nsbH8DPG1+Qyq5urrSdDrlblwAlSRJoul0OqiwlzoQ+NJ7oV956vv6+lrPnj2jrg+glMVioWfPnplYiSNtMq0TYS91oKRzm2VZrjblndJr9G87OjpSHMfckQvgk7Isk+/7pkb10v/CPjX1wKo6McLf2f7GeDIw0pc2JR7XdRWGrU2KA+iBMAzluu6gw17q2Ah/x+RE7s7x8fHN/6kAIG12zc7nc11elj7B/T6dqdnf1cnAl+oJfUk6Pz/XfD5nJQ8wYuv1WmEY6sWLF6Yf3dmwlzoc+NJN6McysE7/Ntu2FYYhO3SBEYqiSPP53NSk7G2Xkvyuhr3U8cDfsSwrkjQz/VzHcW7OxgAwbEmSKAgCrVarOh6/zPM8qOPBJnVq0naf7W/kc9PPXa1WevbsmTzPUxzHph8PoAPiOJbneXr27FldYf+8D2Ev9WSEv2NZli8pkqFlm3c5jqPFYkGpBxiAKIq0WCzqCnlpsxInyPO8N6PFXgW+dHOefizDk7m32bat+XyuIAhYww/0SJZliqJIYRjWUaO/7Uqben1W50tM613gSzeTuQtVuC7xUCcnJ/J9n1E/0GFRFCmOY71+/bqJ1/1V0qLLk7P79DLwd+ou8dxm27Z837/5ANCuOI5vPmoeze/0roRzV68DX6pv6eannJycyPM8+b5P2QdoQJZliuNYSZI0NZK/rfNLLg/R+8Df2d6gtVADo/27HMeR53lyXVeu67LMEzAgSRKlaao0TZUkSZ2Trx9zrU35ZhDnswwm8KWb0X4k6aTlrujo6EjT6fTmh8BkMrn5DGBjvV4rTdObz2maKssyk2faVPFamxJOr0f1tw0q8Hcsy/K0CX6n3Z7sd3x8fwWKfx1gSPbdTZGmaVN19zJW2gR90nZHTBtk4O+0WeYB0DuDKt/cZ9CBL92UeeaSztvuC4DOeiEpHFL55j6DD/yd7YathWo4kwdAby21GdVnbXekCaMJ/J1t8M8lBaLUA4zRtTZzfOFYgn5ndIG/c6vUE6jDk7sAjFnpf0E/6NLNPqMN/Nssywq0Cf5GN28BaMSlpCjP86jtjrSNwL9lW+4JxKgf6LvdaD4aW9nmYwj8PSzLcrUJfl+EP9AHK22OWYm6dnl4VxD4B9iGv7/9qO1YZgCFXWkT8jEh/2kEfkHbyV7v1gc/AIDmXElKdh9jnXwti8A3YHuUg3vrgx8CQHVXktLdxxCPOmgagV+T7QTwVJsfAJNbnyVWAwHSZvWMJK21CfXd54yJ1noQ+AAwEg/a7gAAoBkEPgCMBIEPACNB4APASBD4ADASBD4AjASBDwAjQeADwEgQ+AAwEv8PlRvxANNLSQsAAAAASUVORK5CYII=
+  mediatype: image/png
+name: compliance-operator
+schema: olm.package
+---
+entries:
+- name: compliance-operator.v0.1.32
+  skipRange: '>=0.1.17 <0.1.32'
+name: "4.7"
+package: compliance-operator
+schema: olm.channel
+---
+entries:
+- name: compliance-operator.v0.1.61
+  skipRange: '>=0.1.17 <0.1.61'
+name: release-0.1
+package: compliance-operator
+schema: olm.channel
+---
+entries:
+- name: compliance-operator.v1.4.0
+  skipRange: '>=0.1.17 <1.4.0'
+- name: compliance-operator.v1.4.1
+  replaces: compliance-operator.v1.4.0
+  skipRange: '>=0.1.17 <1.4.1'
+- name: compliance-operator.v1.5.0
+  replaces: compliance-operator.v1.4.1
+  skipRange: '>=0.1.17 <1.5.0'
+- name: compliance-operator.v1.5.1
+  replaces: compliance-operator.v1.5.0
+  skipRange: '>=0.1.17 <1.5.1'
+- name: compliance-operator.v1.6.0
+  replaces: compliance-operator.v1.5.1
+  skipRange: '>=0.1.17 <1.6.0'
+- name: compliance-operator.v1.6.1
+  replaces: compliance-operator.v1.6.0
+  skipRange: '>=0.1.17 <1.6.1'
+- name: compliance-operator.v1.6.2
+  replaces: compliance-operator.v1.6.1
+  skipRange: '>=0.1.17 <1.6.2'
+- name: compliance-operator.v1.7.0
+  replaces: compliance-operator.v1.6.2
+  skipRange: '>=0.1.17 <1.7.0'
+- name: compliance-operator.v1.7.1
+  replaces: compliance-operator.v1.7.0
+  skipRange: '>=1.0.0 <1.7.1'
+- name: compliance-operator.v1.8.0
+  replaces: compliance-operator.v1.7.1
+  skipRange: '>=1.0.0 <1.8.0'
+- name: compliance-operator.v1.8.1
+  replaces: compliance-operator.v1.8.0
+  skipRange: '>=1.0.0 <1.8.1'
+- name: compliance-operator.v1.8.2
+  replaces: compliance-operator.v1.8.1
+  skipRange: '>=1.0.0 <1.8.2'
+- name: compliance-operator.v1.9.0
+  replaces: compliance-operator.v1.8.2
+  skipRange: '>=1.0.0 <1.9.0'
+- name: compliance-operator.v1.9.1
+  replaces: compliance-operator.v1.9.0
+  skipRange: '>=1.0.0 <1.9.1'
+- name: compliance-operator.v1.9.2
+  replaces: compliance-operator.v1.9.1
+  skipRange: '>=1.0.0 <1.9.2'
+name: stable
+package: compliance-operator
+schema: olm.channel
+---
+image: registry.redhat.io/openshift4/compliance-rhel8-operator-metadata@sha256:1c06868bce1f5d7145ef658bfcc284c44011aa24a17166aa124547b38f2259e4
+name: compliance-operator.v0.1.32
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 0.1.32
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/openshift4/compliance-content-rhel8@sha256:4529b9bb32c1846a38e38363fa872713b1c1e6b26b34d887813432f97cff368c",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/openshift4/compliance-content-rhel8@sha256:4529b9bb32c1846a38e38363fa872713b1c1e6b26b34d887813432f97cff368c",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/openshift4/compliance-content-rhel8@sha256:4529b9bb32c1846a38e38363fa872713b1c1e6b26b34d887813432f97cff368c"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      olm.skipRange: '>=0.1.17 <0.1.32'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
+      repository: https://github.com/openshift/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    links:
+    - name: Compliance Operator upstream repo
+      url: https://github.com/openshift/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/4.7/security/compliance_operator/compliance-operator-understanding.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/openshift4/compliance-content-rhel8@sha256:4529b9bb32c1846a38e38363fa872713b1c1e6b26b34d887813432f97cff368c
+  name: profile
+- image: registry.redhat.io/openshift4/compliance-content-rhel8@sha256:4529b9bb32c1846a38e38363fa872713b1c1e6b26b34d887813432f97cff368c
+  name: compliance-content-rhel8-4529b9bb32c1846a38e38363fa872713b1c1e6b26b34d887813432f97cff368c-annotation
+- image: registry.redhat.io/openshift4/compliance-openscap-rhel8@sha256:867c6d4205653d8a954d234cbaf470313009eb983d4f455fb45f49c4a7764422
+  name: openscap
+- image: registry.redhat.io/openshift4/compliance-rhel8-operator-metadata@sha256:1c06868bce1f5d7145ef658bfcc284c44011aa24a17166aa124547b38f2259e4
+  name: ""
+- image: registry.redhat.io/openshift4/compliance-rhel8-operator@sha256:ed68a0574ddeaf7d676403cd843f28cb586894f35dbb3ca5e06a5264bd42f030
+  name: compliance-operator
+- image: registry.redhat.io/openshift4/compliance-rhel8-operator@sha256:ed68a0574ddeaf7d676403cd843f28cb586894f35dbb3ca5e06a5264bd42f030
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:8a2194d8d26dff03ec53ac0ab93c62c268e48675079a88db18bb14a977a391be
+name: compliance-operator.v0.1.61
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 0.1.61
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:c4bf5b2b20ff538adbc430b7ee993fbd7c291203a9810534005148304e3b169b",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:c4bf5b2b20ff538adbc430b7ee993fbd7c291203a9810534005148304e3b169b",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:c4bf5b2b20ff538adbc430b7ee993fbd7c291203a9810534005148304e3b169b"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      olm.skipRange: '>=0.1.17 <0.1.61'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repo
+      url: https://github.com/openshift/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:c4bf5b2b20ff538adbc430b7ee993fbd7c291203a9810534005148304e3b169b
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:c4bf5b2b20ff538adbc430b7ee993fbd7c291203a9810534005148304e3b169b
+  name: openshift-compliance-content-rhel8-c4bf5b2b20ff538adbc430b7ee993fbd7c291203a9810534005148304e3b169b-annotation
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:83ad3113964ec48c5cf28315d923adb6edb95e45960e2756665d617dcd9b2e47
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:8a2194d8d26dff03ec53ac0ab93c62c268e48675079a88db18bb14a977a391be
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:5578e2225365ac1c15e4c189c5c7a8d14fd3fd26189414b36028f7f0879bb1dc
+  name: compliance-operator
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:5578e2225365ac1c15e4c189c5c7a8d14fd3fd26189414b36028f7f0879bb1dc
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:f176e3a1ca1c77fb285bae8d9009a91abf310363eed4fc79a778b7306a38e480
+name: compliance-operator.v1.4.0
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.4.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:7c1285f294f4630766bf158924ea7eff9b6549b2a9881e6dea6bad07887525a0",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:7c1285f294f4630766bf158924ea7eff9b6549b2a9881e6dea6bad07887525a0",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:7c1285f294f4630766bf158924ea7eff9b6549b2a9881e6dea6bad07887525a0"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      olm.skipRange: '>=0.1.17 <1.4.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:7c1285f294f4630766bf158924ea7eff9b6549b2a9881e6dea6bad07887525a0
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:7c1285f294f4630766bf158924ea7eff9b6549b2a9881e6dea6bad07887525a0
+  name: openshift-compliance-content-rhel8-7c1285f294f4630766bf158924ea7eff9b6549b2a9881e6dea6bad07887525a0-annotation
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:cc9faf4820afd8bc94622528f340602cee13691f7511152e2da393a859250b0a
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:f176e3a1ca1c77fb285bae8d9009a91abf310363eed4fc79a778b7306a38e480
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:f00b64570a1e753f68e617d3583956d71084073541f50d7c2e3ac9d66d6a0486
+  name: compliance-operator
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:f00b64570a1e753f68e617d3583956d71084073541f50d7c2e3ac9d66d6a0486
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:cf9d9e16e4660cfff746b3517d32fc73f4d9716d61c5bcae60a60a8fb42ae38e
+name: compliance-operator.v1.4.1
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.4.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:5af18a9f28eadeea4087eee1efc41f85153a85ac2e3372de3c35fc5bcd5a361c",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:5af18a9f28eadeea4087eee1efc41f85153a85ac2e3372de3c35fc5bcd5a361c",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:5af18a9f28eadeea4087eee1efc41f85153a85ac2e3372de3c35fc5bcd5a361c"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=0.1.17 <1.4.1'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:dee91b7c0551a01fe2a3e6fcf3788e76f3ab5be8daa5ca59709840af6592203a
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:5af18a9f28eadeea4087eee1efc41f85153a85ac2e3372de3c35fc5bcd5a361c
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:5af18a9f28eadeea4087eee1efc41f85153a85ac2e3372de3c35fc5bcd5a361c
+  name: openshift-compliance-openscap-rhel8-5af18a9f28eadeea4087eee1efc41f85153a85ac2e3372de3c35fc5bcd5a361c-annotation
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:cf9d9e16e4660cfff746b3517d32fc73f4d9716d61c5bcae60a60a8fb42ae38e
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:9fd537c417480d608f0f299564303eb1153d7aaa83b605c4de282f856eca39fa
+  name: compliance-operator
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:9fd537c417480d608f0f299564303eb1153d7aaa83b605c4de282f856eca39fa
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:a4f4aabb46ca34f6bdd63e752f6b7de37ac41fed6cf87709506857b4819d4e98
+name: compliance-operator.v1.5.0
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.5.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:a92792041cc697aeff51b543bf62a85bc56a70427b2f0b90d11149effe93ed4f",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:a92792041cc697aeff51b543bf62a85bc56a70427b2f0b90d11149effe93ed4f",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:a92792041cc697aeff51b543bf62a85bc56a70427b2f0b90d11149effe93ed4f"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=0.1.17 <1.5.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:5d484bbfee6c70aa604aece7031305c07335d2ce4a4cd827c7733452c41c0742
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:a92792041cc697aeff51b543bf62a85bc56a70427b2f0b90d11149effe93ed4f
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:a92792041cc697aeff51b543bf62a85bc56a70427b2f0b90d11149effe93ed4f
+  name: openshift-compliance-openscap-rhel8-a92792041cc697aeff51b543bf62a85bc56a70427b2f0b90d11149effe93ed4f-annotation
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:a4f4aabb46ca34f6bdd63e752f6b7de37ac41fed6cf87709506857b4819d4e98
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:2f53eddedfec4f6565b698a843c060aa00b6fa6f88888e1b0cc20c604b63ca26
+  name: compliance-operator
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:2f53eddedfec4f6565b698a843c060aa00b6fa6f88888e1b0cc20c604b63ca26
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:91546ecf49cb877652a69f2773054af56c6cf5011d61ab190e1cfee156fc66f9
+name: compliance-operator.v1.5.1
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.5.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:dddc04167415729e51f962ff7baa3ebeb6093867e7702f2613cd0615e1825882",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:dddc04167415729e51f962ff7baa3ebeb6093867e7702f2613cd0615e1825882",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:dddc04167415729e51f962ff7baa3ebeb6093867e7702f2613cd0615e1825882"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=0.1.17 <1.5.1'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:a26f0ad9b48cdb4e65312f4066033ca018feafc0033013240692407f74b28430
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:dddc04167415729e51f962ff7baa3ebeb6093867e7702f2613cd0615e1825882
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:dddc04167415729e51f962ff7baa3ebeb6093867e7702f2613cd0615e1825882
+  name: openshift-compliance-openscap-rhel8-dddc04167415729e51f962ff7baa3ebeb6093867e7702f2613cd0615e1825882-annotation
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:91546ecf49cb877652a69f2773054af56c6cf5011d61ab190e1cfee156fc66f9
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:134b24ed52ec515fec3b268e9c859a7cfb15db56707de5eee0cb4253776d0329
+  name: compliance-operator
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:134b24ed52ec515fec3b268e9c859a7cfb15db56707de5eee0cb4253776d0329
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:8e2ae4ec6fb99d69494763893be9e0a22f85f7fdfcfe09d90df07909c94877be
+name: compliance-operator.v1.6.0
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.6.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:6fbf5179f0738224f498b12e6b3756f53993c8c441020a78ff133b433ed0b44d",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:6fbf5179f0738224f498b12e6b3756f53993c8c441020a78ff133b433ed0b44d",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:6fbf5179f0738224f498b12e6b3756f53993c8c441020a78ff133b433ed0b44d"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=0.1.17 <1.6.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:079ae32f6705235f47ad2084496d80509e3dfe76b104bd3e9499af87af114116
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:a1151d854a47d0aaa1777bf715e220fb022630705896f6b217f2b71187b66684
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:6fbf5179f0738224f498b12e6b3756f53993c8c441020a78ff133b433ed0b44d
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:6fbf5179f0738224f498b12e6b3756f53993c8c441020a78ff133b433ed0b44d
+  name: openshift-compliance-openscap-rhel8-6fbf5179f0738224f498b12e6b3756f53993c8c441020a78ff133b433ed0b44d-annotation
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:8e2ae4ec6fb99d69494763893be9e0a22f85f7fdfcfe09d90df07909c94877be
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:f4c8a1837dc62b16f0ad86f402a6ca38d208ff4abbbb64d41ab486323b7eceef
+  name: compliance-operator
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:f4c8a1837dc62b16f0ad86f402a6ca38d208ff4abbbb64d41ab486323b7eceef
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:3e3061777afbdf83d18258380af8ed74a347e3daa5d0b647ed13711698c58a0f
+name: compliance-operator.v1.6.1
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.6.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:52c1c5cd622f9dbded7e466d7529db7722c00350c66bcbd3b0a904171b4f4184",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:52c1c5cd622f9dbded7e466d7529db7722c00350c66bcbd3b0a904171b4f4184",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:52c1c5cd622f9dbded7e466d7529db7722c00350c66bcbd3b0a904171b4f4184"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=0.1.17 <1.6.1'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:b286929357b82f8ff3845f535bab23382bf06f075ff2379063e2456f1a93e809
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:81cfb7ecb96e48c08d8cfec0e519df3c8502be11490043a9b0a1aae2e8f8e174
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:52c1c5cd622f9dbded7e466d7529db7722c00350c66bcbd3b0a904171b4f4184
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:52c1c5cd622f9dbded7e466d7529db7722c00350c66bcbd3b0a904171b4f4184
+  name: openshift-compliance-openscap-rhel8-52c1c5cd622f9dbded7e466d7529db7722c00350c66bcbd3b0a904171b4f4184-annotation
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:3e3061777afbdf83d18258380af8ed74a347e3daa5d0b647ed13711698c58a0f
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:6f81b37e7dc8d4f328ea78aaf0e1dbbad6c30fc026c7851f306533c829fc8751
+  name: compliance-operator
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:6f81b37e7dc8d4f328ea78aaf0e1dbbad6c30fc026c7851f306533c829fc8751
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:03b7732826883935542572da68d92cd2e73076a762399ad433a5903450b58c39
+name: compliance-operator.v1.6.2
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.6.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:b64926c3cd92381b31f31f28ca01f05c52bc0fbbc581941ba6f0da5b3b142d36",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:b64926c3cd92381b31f31f28ca01f05c52bc0fbbc581941ba6f0da5b3b142d36",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:b64926c3cd92381b31f31f28ca01f05c52bc0fbbc581941ba6f0da5b3b142d36"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=0.1.17 <1.6.2'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:75ebf09b17c6f7894742cab703023252e9e135f9eed3aca38826e12c32342d4b
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:600cf9a44563e6bf07d9dc47c37ad07143065fecbd79db0278eb2236c3122a96
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:b64926c3cd92381b31f31f28ca01f05c52bc0fbbc581941ba6f0da5b3b142d36
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:b64926c3cd92381b31f31f28ca01f05c52bc0fbbc581941ba6f0da5b3b142d36
+  name: openshift-compliance-openscap-rhel8-b64926c3cd92381b31f31f28ca01f05c52bc0fbbc581941ba6f0da5b3b142d36-annotation
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:03b7732826883935542572da68d92cd2e73076a762399ad433a5903450b58c39
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:927770ef61539645fe5d1d62ad9411bdb2f64ec2cd479b3549d9ce914a4c3701
+  name: compliance-operator
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:927770ef61539645fe5d1d62ad9411bdb2f64ec2cd479b3549d9ce914a4c3701
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:49353c2eefa3bb062589a3d6d24f81e063e9911ce1920556d5a801d3afa9bf6b
+name: compliance-operator.v1.7.0
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:6d1805a9027ee56f7819a0055621391cf25c27e67a5c07f5bfa1cf3629f04cc7",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:6d1805a9027ee56f7819a0055621391cf25c27e67a5c07f5bfa1cf3629f04cc7",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:6d1805a9027ee56f7819a0055621391cf25c27e67a5c07f5bfa1cf3629f04cc7"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=0.1.17 <1.7.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:27212fdeb6c35bd96700fd6de8e74d541e0591f1c74448b293e2c850c0291c09
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:fa29e6e4f36b9fb9e9b7d14ed28b90556e2f99d3e80c35aea76896ce388c7e87
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:6d1805a9027ee56f7819a0055621391cf25c27e67a5c07f5bfa1cf3629f04cc7
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:6d1805a9027ee56f7819a0055621391cf25c27e67a5c07f5bfa1cf3629f04cc7
+  name: openshift-compliance-openscap-rhel8-6d1805a9027ee56f7819a0055621391cf25c27e67a5c07f5bfa1cf3629f04cc7-annotation
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:49353c2eefa3bb062589a3d6d24f81e063e9911ce1920556d5a801d3afa9bf6b
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:bdc3f6a0f431761d4367f81f7f67ba45b6efed886bba3307f37d233a10ab69ae
+  name: compliance-operator
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:bdc3f6a0f431761d4367f81f7f67ba45b6efed886bba3307f37d233a10ab69ae
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:06e4abf4a94d44728b6bfa685b6ed027962b60fc2a0060a7256297857fd5f6fa
+name: compliance-operator.v1.7.1
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.7.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:0a5629fd6f6b77cb36734eb663b847f51d45050532cb895c821e00416a1324e4",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:0a5629fd6f6b77cb36734eb663b847f51d45050532cb895c821e00416a1324e4",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:0a5629fd6f6b77cb36734eb663b847f51d45050532cb895c821e00416a1324e4"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      must-gather-image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:e6468ccc55d72539b7fb980d0bce5c072e85879d4e9db39974d53eaab4d32b25
+      olm.skipRange: '>=0.1.17 <1.7.1'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:8d3257bd6a020df53f8d7a400ae877ae029c78ffcd8ec9e35270ee3ff5c8e509
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:e6468ccc55d72539b7fb980d0bce5c072e85879d4e9db39974d53eaab4d32b25
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:d0f89d82845c6245a18e7db345ac3be92b2863d57f55f63e21652086128920c9
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:06e4abf4a94d44728b6bfa685b6ed027962b60fc2a0060a7256297857fd5f6fa
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:0a5629fd6f6b77cb36734eb663b847f51d45050532cb895c821e00416a1324e4
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:0bc0b7a20ce3c6303a45a699f44d2b90597b6a62846e89a5bca285b3228a9a52
+name: compliance-operator.v1.8.0
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: CustomRule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.8.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:1a9ed321d28da1ae089684d4bfb1c206a6ca2442f5725656c48c6c309e128e77",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:1a9ed321d28da1ae089684d4bfb1c206a6ca2442f5725656c48c6c309e128e77",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:1a9ed321d28da1ae089684d4bfb1c206a6ca2442f5725656c48c6c309e128e77"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      must-gather-image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:83ea492a55fb2f2bc423ce7d1ccd31644de8ce492e9d273da47a93413fc9282a
+      olm.skipRange: '>=0.1.17 <1.8.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: CustomRule represents a rule that can be used with TailoredProfiles
+          to execute arbitrary checks against the cluster.
+        displayName: Custom Rule
+        kind: CustomRule
+        name: customrules.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:7b84f08a7f0a808bd92c9540dd5b976b8aa20ed426ce2d646131123e13df60c2
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:83ea492a55fb2f2bc423ce7d1ccd31644de8ce492e9d273da47a93413fc9282a
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:26cbd3cedf1b49bf26d638014ca2fb2196e5a2ed915234721b4ac8679e399011
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:0bc0b7a20ce3c6303a45a699f44d2b90597b6a62846e89a5bca285b3228a9a52
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:1a9ed321d28da1ae089684d4bfb1c206a6ca2442f5725656c48c6c309e128e77
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:4d0f9d6fd1a4856a870e48b99dc3714de17a65813e0caea50564cd63c79f11ab
+name: compliance-operator.v1.8.1
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: CustomRule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.8.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:2cb9373c86d7961fa7d26b5449a717722b790bf64d60c0a987f70f731ec8328e",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:2cb9373c86d7961fa7d26b5449a717722b790bf64d60c0a987f70f731ec8328e",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:2cb9373c86d7961fa7d26b5449a717722b790bf64d60c0a987f70f731ec8328e"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      must-gather-image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:42e581c6934e3205bcd151dab35b87ef124e011f73ffe97ba10b56353a28a641
+      olm.skipRange: '>=0.1.17 <1.8.1'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: CustomRule represents a rule that can be used with TailoredProfiles
+          to execute arbitrary checks against the cluster.
+        displayName: Custom Rule
+        kind: CustomRule
+        name: customrules.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:aa090e2fb3a81cde8096ad3cccfed221701f57d9f2fc80ed0b6e91986a94b9c6
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:42e581c6934e3205bcd151dab35b87ef124e011f73ffe97ba10b56353a28a641
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:4a6eb912f1900b5cca7b1cf5484639b811490f2532e766bf903c0d5ca0ba2ea8
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:4d0f9d6fd1a4856a870e48b99dc3714de17a65813e0caea50564cd63c79f11ab
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:2cb9373c86d7961fa7d26b5449a717722b790bf64d60c0a987f70f731ec8328e
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:ddc2f107588e25d38af6eb58c7b106124f447deae8090ce4d78eead12487d1bf
+name: compliance-operator.v1.8.2
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: CustomRule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.8.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:5f8566e8d351468005957d203503f6a8d04fc79b2bcf53c1ef197fa02edaa762",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:5f8566e8d351468005957d203503f6a8d04fc79b2bcf53c1ef197fa02edaa762",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:5f8566e8d351468005957d203503f6a8d04fc79b2bcf53c1ef197fa02edaa762"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      must-gather-image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:e4a2e3eb5cf845d3bee59555c7d63ab440fd77cb7e42c34a77a66744b03fdc5f
+      olm.skipRange: '>=0.1.17 <1.8.2'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceRemediation represents a remediation that can be applied
+          to the cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceScan represents a scan with a certain configuration
+          that will be applied to objects of a certain entity in the host. These could
+          be nodes that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: ComplianceSuite represents a set of scans that will be applied
+          to the cluster. These should help deployers achieve a certain compliance
+          target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: CustomRule represents a rule that can be used with TailoredProfiles
+          to execute arbitrary checks against the cluster.
+        displayName: Custom Rule
+        kind: CustomRule
+        name: customrules.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:99fa315d40b3fbd82ec593054abb466f67685cd337170ab8f014fc68ffb68e8e
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:e4a2e3eb5cf845d3bee59555c7d63ab440fd77cb7e42c34a77a66744b03fdc5f
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:c16b188963ef3a2003c9b6deef8a4a05ac06427457093874347bde5b7c4554a5
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:ddc2f107588e25d38af6eb58c7b106124f447deae8090ce4d78eead12487d1bf
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:5f8566e8d351468005957d203503f6a8d04fc79b2bcf53c1ef197fa02edaa762
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:e2cbcab60fad0718e63a8c9bacaca97d205735e968505a56ae1a1c523d5ee2da
+name: compliance-operator.v1.9.0
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: CustomRule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.9.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:76b0efb50f8812ac5ff6fb110625fae4aa0f6f9c6b16d4a659735c598dd5974c",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:76b0efb50f8812ac5ff6fb110625fae4aa0f6f9c6b16d4a659735c598dd5974c",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:76b0efb50f8812ac5ff6fb110625fae4aa0f6f9c6b16d4a659735c598dd5974c"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      createdAt: "2026-04-02T21:16:58Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      must-gather-image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:d1f394c1054e8bd8ded223b6fc07a83658ffa3c6e78679b67365f546cb4293fd
+      olm.skipRange: '>=0.1.17 <1.9.0'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.42.2
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: |-
+          ComplianceRemediation represents a remediation that can be applied to the
+          cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: |-
+          ComplianceScan represents a scan with a certain configuration that will be
+          applied to objects of a certain entity in the host. These could be nodes
+          that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: |-
+          ComplianceSuite represents a set of scans that will be applied to the
+          cluster. These should help deployers achieve a certain compliance target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: CustomRule represents a user-created rule for use with TailoredProfiles
+          to execute arbitrary checks against the cluster.
+        displayName: Custom Rule
+        kind: CustomRule
+        name: customrules.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:1c58fd6824b86368e74ba9868d77cdb7cae800e4d44a0f72297547019139b13d
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:d1f394c1054e8bd8ded223b6fc07a83658ffa3c6e78679b67365f546cb4293fd
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:427077038c18956989ab928cdc7338f70b2fc7cf4c6980547c9a0f88db00d0ca
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:e2cbcab60fad0718e63a8c9bacaca97d205735e968505a56ae1a1c523d5ee2da
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:76b0efb50f8812ac5ff6fb110625fae4aa0f6f9c6b16d4a659735c598dd5974c
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:dd5ac6b523658a5d8a07c39e20b6538686d8680d16aec8ffb0c0568a586d34be
+name: compliance-operator.v1.9.1
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: CustomRule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.9.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:7a73f8147c2ffa5c0a96ab8d0e6f81226e5e6facaf56e07fb420dcaa1249591a",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:7a73f8147c2ffa5c0a96ab8d0e6f81226e5e6facaf56e07fb420dcaa1249591a",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:7a73f8147c2ffa5c0a96ab8d0e6f81226e5e6facaf56e07fb420dcaa1249591a"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      createdAt: "2026-06-11T13:25:22Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      must-gather-image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:4e6a00a6396fb83f575558ed69fa171701e39601ee4532c2cb519aa19cab75f8
+      olm.skipRange: '>=0.1.17 <1.9.1'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.42.2
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: |-
+          ComplianceRemediation represents a remediation that can be applied to the
+          cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: |-
+          ComplianceScan represents a scan with a certain configuration that will be
+          applied to objects of a certain entity in the host. These could be nodes
+          that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: |-
+          ComplianceSuite represents a set of scans that will be applied to the
+          cluster. These should help deployers achieve a certain compliance target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: CustomRule represents a user-created rule for use with TailoredProfiles
+          to execute arbitrary checks against the cluster.
+        displayName: Custom Rule
+        kind: CustomRule
+        name: customrules.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:9301eb1abc279ebac151b65c1793422f921322a9a6ff409daf1ee225020a1cf7
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:4e6a00a6396fb83f575558ed69fa171701e39601ee4532c2cb519aa19cab75f8
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:b2280778f88d4ac8d5204d28fee8c5cc0078a79dfda76223e167d4b21fa5d7ad
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:dd5ac6b523658a5d8a07c39e20b6538686d8680d16aec8ffb0c0568a586d34be
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:7a73f8147c2ffa5c0a96ab8d0e6f81226e5e6facaf56e07fb420dcaa1249591a
+  name: operator
+schema: olm.bundle
+---
+image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:bfe946d2878a37624641a92ed538c77861c355fb4a44a387944d988feca7ca95
+name: compliance-operator.v1.9.2
+package: compliance-operator
+properties:
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceCheckResult
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceRemediation
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceScan
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ComplianceSuite
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: CustomRule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Profile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ProfileBundle
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Rule
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSetting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: ScanSettingBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: TailoredProfile
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: compliance.openshift.io
+    kind: Variable
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: compliance-operator
+    version: 1.9.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-node"
+            },
+            "spec": {
+              "content": "ssg-rhcos4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceScan",
+            "metadata": {
+              "name": "example-compliancescan-platform"
+            },
+            "spec": {
+              "content": "ssg-ocp4-ds.xml",
+              "profile": "xccdf_org.ssgproject.content_profile_moderate",
+              "scanType": "Platform"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ComplianceSuite",
+            "metadata": {
+              "name": "example-compliancesuite"
+            },
+            "spec": {
+              "autoApplyRemediations": false,
+              "scans": [
+                {
+                  "content": "ssg-rhcos4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:5dea57e7e693fe5e399b6866d00d4246afda3a755dafdd0bfe4df5a1952a9437",
+                  "name": "workers-scan",
+                  "nodeSelector": {
+                    "node-role.kubernetes.io/worker": ""
+                  },
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate"
+                },
+                {
+                  "content": "ssg-ocp4-ds.xml",
+                  "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:5dea57e7e693fe5e399b6866d00d4246afda3a755dafdd0bfe4df5a1952a9437",
+                  "name": "platform-scan",
+                  "profile": "xccdf_org.ssgproject.content_profile_moderate",
+                  "scanType": "Platform"
+                }
+              ],
+              "schedule": "0 1 * * *"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ProfileBundle",
+            "metadata": {
+              "name": "ocp4"
+            },
+            "spec": {
+              "contentFile": "ssg-ocp4-ds.xml",
+              "contentImage": "registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:5dea57e7e693fe5e399b6866d00d4246afda3a755dafdd0bfe4df5a1952a9437"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "autoApplyRemediations": false,
+            "debug": true,
+            "kind": "ScanSetting",
+            "metadata": {
+              "name": "my-companys-constraints"
+            },
+            "rawResultStorage": {
+              "rotation": 10,
+              "size": "2Gi"
+            },
+            "roles": [
+              "worker",
+              "master"
+            ],
+            "schedule": "0 1 * * *"
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "ScanSettingBinding",
+            "metadata": {
+              "name": "nist-moderate"
+            },
+            "profiles": [
+              {
+                "apiGroup": "compliance.openshift.io/v1alpha1",
+                "kind": "Profile",
+                "name": "rhcos4-moderate"
+              }
+            ],
+            "settingsRef": {
+              "apiGroup": "compliance.openshift.io/v1alpha1",
+              "kind": "ScanSetting",
+              "name": "default"
+            }
+          },
+          {
+            "apiVersion": "compliance.openshift.io/v1alpha1",
+            "kind": "TailoredProfile",
+            "metadata": {
+              "name": "example-tailoredprofile"
+            },
+            "spec": {
+              "description": "Example of a tailoredProfile that extends OCP4 FedRAMP Moderate",
+              "disableRules": [
+                {
+                  "name": "ocp4-file-permissions-node-config",
+                  "rationale": "This breaks X application."
+                },
+                {
+                  "name": "ocp4-account-disable-post-pw-expiration",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-accounts-no-uid-except-zero",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-chown",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmod",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchmodat",
+                  "rationale": "testing this"
+                },
+                {
+                  "name": "ocp4-audit-rules-dac-modification-fchown",
+                  "rationale": "testing this"
+                }
+              ],
+              "extends": "ocp4-moderate",
+              "setValues": [
+                {
+                  "name": "ocp4-var-selinux-state",
+                  "rationale": "trolling dwalsh",
+                  "value": "permissive"
+                }
+              ],
+              "title": "My little profile"
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Monitoring,Security
+      createdAt: "2026-08-06T09:33:37Z"
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      must-gather-image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:e98c64d66ca2a867345e5e2c1bec67c414e49ea49393f345737c3d2754324d8b
+      olm.skipRange: '>=0.1.17 <1.9.2'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-compliance
+      operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
+        "OpenShift Container Platform", "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.42.2
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/ComplianceAsCode/compliance-operator
+      support: Red Hat Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ComplianceCheckResult represent a result of a single compliance
+          "test"
+        kind: ComplianceCheckResult
+        name: compliancecheckresults.compliance.openshift.io
+        version: v1alpha1
+      - description: |-
+          ComplianceRemediation represents a remediation that can be applied to the
+          cluster to fix the found issues.
+        displayName: Compliance Remediation
+        kind: ComplianceRemediation
+        name: complianceremediations.compliance.openshift.io
+        version: v1alpha1
+      - description: |-
+          ComplianceScan represents a scan with a certain configuration that will be
+          applied to objects of a certain entity in the host. These could be nodes
+          that apply to a certain nodeSelector, or the cluster itself.
+        displayName: Compliance Scan
+        kind: ComplianceScan
+        name: compliancescans.compliance.openshift.io
+        version: v1alpha1
+      - description: |-
+          ComplianceSuite represents a set of scans that will be applied to the
+          cluster. These should help deployers achieve a certain compliance target.
+        displayName: Compliance Suite
+        kind: ComplianceSuite
+        name: compliancesuites.compliance.openshift.io
+        version: v1alpha1
+      - description: CustomRule represents a user-created rule for use with TailoredProfiles
+          to execute arbitrary checks against the cluster.
+        displayName: Custom Rule
+        kind: CustomRule
+        name: customrules.compliance.openshift.io
+        version: v1alpha1
+      - description: ProfileBundle is the Schema for the profilebundles API
+        displayName: Profile Bundle
+        kind: ProfileBundle
+        name: profilebundles.compliance.openshift.io
+        version: v1alpha1
+      - description: Profile is the Schema for the profiles API
+        kind: Profile
+        name: profiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Rule is the Schema for the rules API
+        kind: Rule
+        name: rules.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSettingBinding is the Schema for the scansettingbindings
+          API
+        displayName: Scan Setting Binding
+        kind: ScanSettingBinding
+        name: scansettingbindings.compliance.openshift.io
+        version: v1alpha1
+      - description: ScanSetting is the Schema for the scansettings API
+        kind: ScanSetting
+        name: scansettings.compliance.openshift.io
+        version: v1alpha1
+      - description: TailoredProfile is the Schema for the tailoredprofiles API
+        displayName: Tailored Profile
+        kind: TailoredProfile
+        name: tailoredprofiles.compliance.openshift.io
+        version: v1alpha1
+      - description: Variable describes a tunable in the XCCDF profile
+        kind: Variable
+        name: variables.compliance.openshift.io
+        version: v1alpha1
+    description: An operator which runs OpenSCAP and allows you to keep your cluster
+      compliant with the security benchmark you need.
+    displayName: Compliance Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - security
+    - compliance
+    - openscap
+    - audit
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Compliance Operator upstream repository
+      url: https://github.com/ComplianceAsCode/compliance-operator
+    - name: Compliance Operator documentation
+      url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat Inc.
+      url: www.redhat.com
+relatedImages:
+- image: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:d219ac3c23d139f6a426ce427d7816b4a3c4abbfa5bc1bf1b318ccfa53b1cdc4
+  name: profile
+- image: registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:e98c64d66ca2a867345e5e2c1bec67c414e49ea49393f345737c3d2754324d8b
+  name: must-gather
+- image: registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:b1b2cf0bb2aa7029b72b3866ccba5e420462cc2761cf3ae7d7731f85a763c586
+  name: openscap
+- image: registry.redhat.io/compliance/openshift-compliance-operator-bundle@sha256:bfe946d2878a37624641a92ed538c77861c355fb4a44a387944d988feca7ca95
+  name: ""
+- image: registry.redhat.io/compliance/openshift-compliance-rhel8-operator@sha256:5dea57e7e693fe5e399b6866d00d4246afda3a755dafdd0bfe4df5a1952a9437
+  name: operator
+schema: olm.bundle

--- a/update.sh
+++ b/update.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # --- CONFIGURATION ---
-OCP_VERSIONS=(4.12 4.13 4.14 4.15 4.16 4.17 4.18 4.19 4.20 4.21 4.22 4.23)
+OCP_VERSIONS=(4.12 4.13 4.14 4.15 4.16 4.17 4.18 4.19 4.20 4.21 4.22 4.23 5.0)
 
 # Old (tag-based) image:
 NEW_BUNDLE="quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-bundle-release:release-1.9"


### PR DESCRIPTION
## Summary
- Add `Containerfile-ocp5.in` template using `registry.redhat.io/openshift5/ose-operator-registry-rhel9` base image
- Update `bootstrap.sh`: default to OCP 5 template, add fallback to copy catalog from previous version, fix `$OCP_V` → `$VERSION` bug
- Add `5.0` to `update.sh` OCP_VERSIONS array
- Bootstrap OCP 5.0 catalog (from 4.23 catalog-template.yaml)
- Generate Tekton pull-request and push pipelines for OCP 5.0

## Test plan
- [x] `opm validate catalog/v5.0/compliance-operator/` passes
- [x] `podman build` with `openshift5/ose-operator-registry-rhel9:v5.0` base image succeeds
- [x] Containerfile correctly references `openshift5` registry path

🤖 Generated with [Claude Code](https://claude.com/claude-code)